### PR TITLE
refactor: render question component in `question.js`

### DIFF
--- a/packages/qa/src/react-components/form/checkbox.js
+++ b/packages/qa/src/react-components/form/checkbox.js
@@ -1,20 +1,17 @@
 import React from 'react'
 import styled from 'styled-components'
 
-
-const CheckboxOptionList = styled.ul`
-    position: relative;
-    margin: 0; 
-    padding: 4px 0;
-        max-height: 240px;
-        overflow-y: auto;
-        overflow-y: auto;
-       
-
+const Title = styled.h3`
+  padding: 16px 0;
+  line-height: 200%;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 150%;
+  box-sizing: border-box;
+  font-family: 'Noto Sans CJK TC', sans-serif;
+  width: 320px;
+  margin:0;
 `
-
-
-
 
 const CheckboxWrapper = styled.section`
     * {
@@ -31,16 +28,20 @@ const CheckboxWrapper = styled.section`
     border-radius: 6px;
     border: 1px solid;
     width: 320px;
-    margin: 0 auto;
     display: flex;
     flex-direction: column;
     padding: 16px 24px 20px;
-
-    h3{
-      margin: 0;
-      line-height: 200%;
-    }
+    margin: 0 0 24px;
   `
+  
+const CheckboxOptionList = styled.ul`
+    position: relative;
+    margin: 0; 
+    padding: 4px 0;
+    max-height: 240px;
+    overflow-y: auto;       
+`
+
 
 const CheckboxOption = styled.li`
   color: #000928;
@@ -103,13 +104,16 @@ const CheckboxOption = styled.li`
 `
 
 const defaultTitle = '這是複選題'
-const mockOptionList = ['選項一', '選項二', '選項三']
 
-export default function Checkbox({ title = defaultTitle, optionList = mockOptionList }) {
-  const optionItem = optionList.map((item, index) =>
-    <CheckboxOption onClick={() => chooseOption(item)} key={index}>
-      <label className='container' htmlFor={index}>{item}
-        <input type="checkbox" id={index} value={item}  defaultChecked='checked' />
+export default function Checkbox({ title = defaultTitle, ...props }) {
+  const optionItem = props.options.map((option) =>
+    <CheckboxOption key={`option-${option.id}`}>
+      <label
+        className='container'
+        htmlFor={`option-${option.id}`}
+        onChange={(e => props.onChange(e.target.value))}
+      >{option.name}
+        <input type="checkbox" id={`option-${option.id}`} value={option.value} />
         <span className="checkmark"></span>
       </label>
 
@@ -117,14 +121,13 @@ export default function Checkbox({ title = defaultTitle, optionList = mockOption
     </CheckboxOption>);
 
   return (
-    <div>
-
+    <React.Fragment>
       <CheckboxWrapper>
-        <h3>{title}</h3>
+        <Title>{title}</Title>
         <CheckboxOptionList>
           {optionItem}
         </CheckboxOptionList>
       </CheckboxWrapper>
-    </div>
+    </React.Fragment>
   )
 }

--- a/packages/qa/src/react-components/form/checkbox.js
+++ b/packages/qa/src/react-components/form/checkbox.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React  from 'react'
 import styled from 'styled-components'
 
 const Title = styled.h3`
@@ -33,7 +33,7 @@ const CheckboxWrapper = styled.section`
     padding: 16px 24px 20px;
     margin: 0 0 24px;
   `
-  
+
 const CheckboxOptionList = styled.ul`
     position: relative;
     margin: 0; 
@@ -105,13 +105,21 @@ const CheckboxOption = styled.li`
 
 const defaultTitle = '這是複選題'
 
-export default function Checkbox({ title = defaultTitle, ...props }) {
+export default function Checkbox({ title = defaultTitle, checkedValue = [], ...props }) {
+  const chooseOption = (option) => {
+    if(checkedValue.indexOf(option)> -1){
+      props.onChange(checkedValue.filter((item)=> item !== option))
+    }else{
+      props.onChange(checkedValue.concat(option))
+    }
+
+  }
   const optionItem = props.options.map((option) =>
     <CheckboxOption key={`option-${option.id}`}>
       <label
         className='container'
         htmlFor={`option-${option.id}`}
-        onChange={(e => props.onChange(e.target.value))}
+        onChange={(e => chooseOption(e.target.value))}
       >{option.name}
         <input type="checkbox" id={`option-${option.id}`} value={option.value} />
         <span className="checkmark"></span>

--- a/packages/qa/src/react-components/form/checkbox.js
+++ b/packages/qa/src/react-components/form/checkbox.js
@@ -1,6 +1,8 @@
 import React  from 'react'
 import styled from 'styled-components'
 
+
+
 const Title = styled.h3`
   padding: 16px 0;
   line-height: 200%;
@@ -104,6 +106,15 @@ const CheckboxOption = styled.li`
 `
 
 const defaultTitle = '這是複選題'
+
+/**
+ *  @param {Object} props
+ *  @param {import('../typedef').Option[]} props.options
+ *  @param {string} props.title
+ *  @param {string[]} props.checkedValue
+ *  @param {Function} props.onChange
+ *  @return React.ReactElement
+ */
 
 export default function Checkbox({ title = defaultTitle, checkedValue = [], ...props }) {
   const chooseOption = (option) => {

--- a/packages/qa/src/react-components/form/dropdown.js
+++ b/packages/qa/src/react-components/form/dropdown.js
@@ -1,6 +1,8 @@
 import React, { useState, useRef } from 'react'
 import styled from 'styled-components'
 
+
+
 const Title =styled.h3`
   padding: 16px 0;
   line-height: 200%;
@@ -87,6 +89,18 @@ const DropdownInput = styled.div`
       }
   `
 const defaultTitle = '這是選項>=4的單選題'
+
+
+/**
+ *  @param {Object} props
+ *  @param {import('../typedef').Option[]} props.options
+ *  @param {string} props.title
+ *  @param {string} props.checkedValue
+ *  @param {Function} props.onChange
+ *  @return React.ReactElement
+ */
+
+
 export default function Dropdown({title=defaultTitle,...props}) {
   const inputRef = useRef(null);
   const [isListOpen, setIsListOpen] = useState(false)

--- a/packages/qa/src/react-components/form/dropdown.js
+++ b/packages/qa/src/react-components/form/dropdown.js
@@ -1,21 +1,32 @@
 import React, { useState, useRef } from 'react'
 import styled from 'styled-components'
 
+const Title =styled.h3`
+  padding: 16px 0;
+  line-height: 200%;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 150%;
+  box-sizing: border-box;
+  font-family: 'Noto Sans CJK TC', sans-serif;
+  width: 320px;
+  margin:0;
+  `
 const DropdownOptionList =styled.ul`
     position: relative;
     margin: 0; 
     padding: 4px 0;
-        max-height: 240px;
-        overflow-y: auto;
-        &::before {
-          content: '';
-          position: absolute;
-          top: 0;
-          right: 16px;
-          left: 16px;
-          height: 1px;
-          background-color: #e0e0e0;
-        }
+    max-height: 240px;
+    overflow-y: auto;
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      right: 16px;
+      left: 16px;
+      height: 1px;
+      background-color: #e0e0e0;
+    }
 
 `
 
@@ -50,6 +61,7 @@ const DropdownWrapper = styled.section`
     display: flex;
     flex-direction: column;
     margin: 0 0 24px;
+
   `
 const DropdownInput = styled.div`
       box-sizing: border-box;
@@ -74,12 +86,11 @@ const DropdownInput = styled.div`
         border-color: #04295e transparent transparent transparent;
       }
   `
+const defaultTitle = '這是選項>=4的單選題'
 const mockOptionList =  ['選項一','選項二','選項三','選項四'] 
-export default function Dropdown({optionList = mockOptionList }) {
+export default function Dropdown({title=defaultTitle,...props}) {
   const inputRef = useRef(null);
-  const [option, setOption] = useState('');
   const [isListOpen, setIsListOpen] = useState(false)
-
   const focusInput = () => {
     inputRef.current.focus();
     inputRef.current.style.borderColor = "#04295e"
@@ -89,22 +100,22 @@ export default function Dropdown({optionList = mockOptionList }) {
     setIsListOpen((isListOpen)=>!isListOpen)
     focusInput()
   }
-  const chooseOption  = (option)=>{
-    setOption(option)
+  const chooseOption = (option)=>{
     toggleList()
+    props.onChange(option)
   }
-
-  const optionItem = optionList.map((item,index) =>
-    <DropdownOption onClick={() => chooseOption(item)} key={index}>
-      {item}
+  const optionItem = props.options.map((option) =>
+    <DropdownOption onClick={() => chooseOption(option.name)} key={`option-${option.id}`}>
+      {option.name}
     </DropdownOption>);
 
 
   return (
-    <div>
+    <React.Fragment>
+      <Title>{title}</Title>
       <DropdownWrapper>
         <DropdownInput ref={inputRef} onClick={toggleList}>
-          <input readOnly placeholder='請選擇' defaultValue={option} />
+          <input readOnly placeholder='請選擇' defaultValue={props.checkedValue} />
           <span className='arrow'></span>
         </DropdownInput>        
         {isListOpen &&
@@ -114,6 +125,6 @@ export default function Dropdown({optionList = mockOptionList }) {
         }
       </DropdownWrapper>
 
-    </div>
+    </React.Fragment>
   )
 }

--- a/packages/qa/src/react-components/form/dropdown.js
+++ b/packages/qa/src/react-components/form/dropdown.js
@@ -87,7 +87,6 @@ const DropdownInput = styled.div`
       }
   `
 const defaultTitle = '這是選項>=4的單選題'
-const mockOptionList =  ['選項一','選項二','選項三','選項四'] 
 export default function Dropdown({title=defaultTitle,...props}) {
   const inputRef = useRef(null);
   const [isListOpen, setIsListOpen] = useState(false)
@@ -105,7 +104,7 @@ export default function Dropdown({title=defaultTitle,...props}) {
     props.onChange(option)
   }
   const optionItem = props.options.map((option) =>
-    <DropdownOption onClick={() => chooseOption(option.name)} key={`option-${option.id}`}>
+    <DropdownOption onClick={() => chooseOption(option.value)} key={`option-${option.id}`}>
       {option.name}
     </DropdownOption>);
 

--- a/packages/qa/src/react-components/question.js
+++ b/packages/qa/src/react-components/question.js
@@ -20,7 +20,6 @@ const SubmitBt = styled.div`
  */
 export default function Question(props) {
   const [answer, setAnswer] = useState([])
-
   let optionsJsx = null
   switch (props.type) {
     // TODO: check what's difference between multiple and checkbox with HC.
@@ -30,8 +29,9 @@ export default function Question(props) {
       optionsJsx = (
         <Checkbox 
           title={props.name}
-          options={props.options} 
-          onChange={(value) => {setAnswer([value])}}
+          options={props.options}
+          checkedValue={answer}
+          onChange={(value) => {setAnswer(value)}}
         />
       )
         

--- a/packages/qa/src/react-components/question.js
+++ b/packages/qa/src/react-components/question.js
@@ -1,4 +1,6 @@
 import Radio from './form/radio'
+import Checkbox from './form/checkbox'
+import Dropdown from './form/dropdown'
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
@@ -25,10 +27,17 @@ export default function Question(props) {
     case 'multiple':
     case 'checkbox': {
       // TODO: add Checkbox component
-      optionsJsx = (<div>render checkbox</div>)
+      optionsJsx = (
+        <Checkbox 
+          title={props.name}
+          options={props.options} 
+          onChange={(value) => {setAnswer([value])}}
+        />
+      )
+        
       break
     }
-
+    
     case 'text': {
       // TODO: add TextArea Component
       break
@@ -36,7 +45,28 @@ export default function Question(props) {
 
     // TODO: discuss with HC
     // since we have to decide to render Radio component or Dropdown component here
-    case 'single':
+    case 'single': {
+      if(props.options.length >=4){
+        optionsJsx = (
+          <Dropdown
+            title={props.name}
+            options={props.options}
+            checkedValue={answer?.[0]}
+            onChange={(value) => {setAnswer([value])}}
+          />
+        )
+      }else {
+        optionsJsx = (
+          <Radio
+            title={props.name}
+            options={props.options}
+            checkedValue={answer?.[0]}
+            onChange={(value) => {setAnswer([value])}}
+          />
+        )
+      }
+      break
+    }
     default: {
       optionsJsx = (
         <Radio


### PR DESCRIPTION
### Notable Change
1. 在 994e0658d535367ed07da0ce248678868b880c60 中，將目前有的三個question component ：`checkbox`、`radio`、`dropdown`加入`question.js`，並依據nick寫好的跳題邏輯，render特定的component。
2. 調整component `checkbox`與`dropdown`的css。

### TODO:
1. 整合button與answer component。
2. 調整component `radio`的css。 
3. 抽出既有元件的部分UI，並元件化。比如說`title`、`card-wrapper`(白色背景、有border、有padding、用來放題目跟選項的wrapper)
還不確定TODO三點要在這個PR做，還是另發PR，可以再討論。