### PR TITLE
refactor(questionnaire): update webpack.config.js. Comment `optimizaiton` property temporarily

### DIFF
--- a/packages/embed-code-generator/webpack.config.js
+++ b/packages/embed-code-generator/webpack.config.js
@@ -72,6 +72,7 @@ const webpackConfig = {
       },
     ],
   },
+  /*
   optimization: {
     splitChunks: {
       chunks: 'all',
@@ -111,6 +112,7 @@ const webpackConfig = {
       },
     },
   },
+  */
   plugins: [new BundleListPlugin()/*, new BundleAnalyzerPlugin()*/ ],
 }
 


### PR DESCRIPTION
### Change Reson
暫時把 webpack 切成不同 chunks 的 optimization 註解掉。
原因若有多個 chunks，產生出來的 embed code 無法在 readr CMS 上使用。
readr CMS `Embed` 按鈕目前在處理多個 `<script>` 上有 bug，需要進一步修理。
要等到 readr CMS 修復後，webpack optimization 才能再度使用。