### PR TITLE
feat(image): add different mode of loading image

### DIFF
--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -5,7 +5,11 @@
 
 ## Feature
 
-- 可依據傳入的多個圖片URL，由小至大依序載入。
+- 可傳入的多個圖片URL，並依序載入。
+- 可選擇兩種載入模式，決定首次載入的圖片尺寸：
+  - `auto`: 可由元件判定裝置螢幕寬度，自動載入最適合的尺寸的圖片。
+  - `manual`：可傳入參數`loadResolution`，由使用者自行決定欲載入的圖片尺寸。
+- 當特定圖片載入成功時，則顯示該圖片；當特定圖片載入失敗時，則載入更大尺寸的圖片。
 - 當所有圖片URL皆載入失敗時，載入預設圖片。
 - 實作圖片載入動畫效果。
 - 實作圖片懶載入（lazy load）。
@@ -17,34 +21,49 @@
 
 ```
 import CustomImage from '@readr-media/react-image'
-const IMAGES_URL = { w400: "400.png", original: "original.png"}
+const IMAGES_URL = { w480: "480.png", w800: "w800.png", original: "original.png"}
 export default function SomeComponent() {
   return (
     <div>
       <OtherComponent/>
-      <CustomImage images={IMAGES_URL}/>
+      
+      {/* If `loadMode` is auto, `CustomImage` will determine which size of image should load first based on screen width, so different URL of image will load on different screen width. */}
+      <CustomImage images={IMAGES_URL} loadMode="auto"/>
+      
+      {/* If `loadMode` is manual, `CustomImage` will determine which size of image should load first based on `loadResolution`. In here, "w800.png" will loaded first regardless of screen width*/}
+      <CustomImage images={IMAGES_URL} loadMode="manual" loadResolution="w800"/>
+
     </div>
   )
 }
 ```
 
 
+
+
 ## Props 
 
-| 名稱           | 資料型別    | 必須  | 預設值              | 說明                                                                                                                                  |
-| ------------ | ------- | --- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| images       | Object  | `V` | `{original: ""}` | 圖片設定，範例： `{ w400: '400.png',w800 : '800.png', w1200: '1200.png', original: 'original.png' }`。會由`w400`、`w800`、`w1200`、`original`依序載入 |
-| defaultImage | String  |     | `""`           | 預設圖片。當`image`皆載入失敗時，則載入預設圖片。<br>當`loadingImage`未傳入時，則以預設圖片作為圖片載入動畫效果。                                                               |
-| loadingImage | String  |     | `""`             | 載入動畫效果，作為載入圖片的動畫。目前僅接受圖片檔URL。                                                                                                       |
-| alt          | String  |     | `""`             | 替代文字                                                                                                                                |
-| objectFit    | String  |     | `"cover"`        | 圖片區塊填滿設定，即為CSS property `object-fit`                                                                                                |
-| height       | String  |     | `"100%"`     | 圖片高度                                                                                                                                |
-| width        | String  |     | `"100%"`         | 圖片寬度                                                                                                                                |
-| debugMode    | Boolean |     | `false`          | 是否開啟開發模式，若開啟，則在載入圖片成功或失敗時，透過`console.log`顯示相關訊息                                                                                     |
+| 名稱         | 資料型別 | 必須 | 預設值           | 說明                                                                                                                                                                                                                                                    |
+| ------------ | -------- | ---- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| images       | Object   | `V`  | `{original: ""}` | 圖片設定，範例： `{ w400: '400.png',w800 : '800.png', w1200: '1200.png', original: 'original.png' }`。會由`w400`、`w800`、`w1200`、`original`依序載入                                                                                                   |
+| defaultImage | String   |      | `""`             | 預設圖片。當`image`皆載入失敗時，則載入預設圖片。<br>當`loadingImage`未傳入時，則以預設圖片作為圖片載入動畫效果。                                                                                                                                       |
+| loadingImage | String   |      | `""`             | 載入動畫效果，作為載入圖片的動畫。目前僅接受圖片檔URL。                                                                                                                                                                                                 |
+| alt          | String   |      | `""`             | 替代文字                                                                                                                                                                                                                                                |
+| objectFit    | String   |      | `"cover"`        | 圖片區塊填滿設定，即為CSS property `object-fit`                                                                                                                                                                                                         |
+| height       | String   |      | `"100%"`         | 圖片高度                                                                                                                                                                                                                                                |
+| width        | String   |      | `"100%"`         | 圖片寬度                                                                                                                                                                                                                                                |
+| loadMode     | String   |      | `"auto"`         | 圖片載入模式，若傳入`"auto"`，則會依據螢幕寬度載入最適合大小的圖片；若傳入`"manual"`，則會依據另一參數`"loadResolution"`，載入指定尺寸的圖片。若loadMode為manual，但`"loadResolution"`為falsy值或不存在參數images屬性的任一件鍵值，則從最小尺寸圖片載入。 |
+| loadResolution|String|      |`"original"`|圖片載入尺寸，只有在另一參數`loadMode`為`"manual"`時才有效。|
+| debugMode    | Boolean  |      | `false`          | 是否開啟開發模式，若開啟，則在載入圖片成功或失敗時，透過`console.log`顯示相關訊息                                                                                                                                                                       |
+
+
+
+
+
 
 
 ## Precautions
-若使用該套件時，禁用了瀏覽器的cache，則同張圖片會載入兩次（一次在函式`loadImage()`中載入各個大小的圖片，一次則在useEffect中，將成功載入的圖片掛載至`<img>`上），這是正常的現象。
+若使用該套件時，禁用了瀏覽器的cache，則同張圖片會載入至少兩次（一次在函式`loadImage()`中載入各個大小的圖片，一次則在useEffect中，將成功載入的圖片掛載至`<img>`上），這是正常的現象。
 之所以要分載入兩次，而不是在`loadImage()`中嘗試載入圖片並掛載至`<img>`，是因為這樣才能在圖片載入時顯示`loadingImage`。
 
 若無禁用瀏覽器快取，則僅會載入一次圖片。
@@ -91,5 +110,4 @@ Note: before publish npm package, we need to bump the package version first.
 ## TODOs
 - [ ] 建立 CI pipeline，透過 CI 產生 npm package，並且上傳至 npm registry
 - [ ] 透過 Lerna 控制 packages 之間的版號
-- [ ] 實作[Responsive Image](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)，並由螢幕寬度決定載入圖片大小。
 - [ ] 在禁用瀏覽器的快取情況下，仍僅需載入圖片一次。

--- a/packages/image/dev/entry.js
+++ b/packages/image/dev/entry.js
@@ -42,6 +42,8 @@ root.render(
         height="100%"
         objectFit="cover"
         debugMode={true}
+        loadMode="manual"
+        loadResolution="w800"
       ></Image>
     ))}
   </div>

--- a/packages/image/dev/index.html
+++ b/packages/image/dev/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>@readr-media/images</title>
+    <title>@readr-media/react-image</title>
   </head>
   <body style="background-color: #f6f6f5; margin: 0;">
     <h1>123</h1>

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-image",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@readr-media/image",
-  "version": "1.0.0",
+  "name": "@readr-media/react-image",
+  "version": "1.0.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/image/src/react-components/index.js
+++ b/packages/image/src/react-components/index.js
@@ -152,8 +152,18 @@ export default function CustomImage({
    * @returns {Promise<string>} - the resolution of image should be loaded
    */
   const getResolution = (imagesList) => {
+    const imagesWidthList = imagesList
+      .filter((pair) => pair[0] !== 'original')
+      .map((pair) => {
+        const regex = /(\d+)/
+        const width = pair[0].match(regex)[0]
+        return width
+      })
     switch (loadMode) {
       case 'auto':
+        const sizes = imagesWidthList
+          .map((width) => `(max-width: ${width}px) ${width}px`)
+          .join(', ')
         return new Promise((resolve, reject) => {
           const img = new Image()
           /**
@@ -183,7 +193,7 @@ export default function CustomImage({
 
           img.addEventListener('load', eventHandler)
           img.addEventListener('error', eventHandler)
-
+          img.sizes = sizes
           img.srcset = imageSrcSet
         })
 

--- a/packages/image/src/react-components/index.js
+++ b/packages/image/src/react-components/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback } from 'react' // eslint-disable-line
+import React, { useEffect, useRef } from 'react' // eslint-disable-line
 
 /**
  *
@@ -26,6 +26,15 @@ import React, { useEffect, useRef, useCallback } from 'react' // eslint-disable-
  * - can set if is in debug mode
  * - if `true`, then will print log after image loaded successfully of occur error.
  * - optional, default value is `false`.
+ * @param {'auto' | 'manual'} [props.loadMode]
+ * - Load images in different mode:
+ * - If `'auto'`, it will automatically load the most suitable picture according to the screen width.
+ * - If `'manual'`, it will load the corresponding picture according to the specified `loadResolution`.
+ * - Optional, default value is `'auto'`
+ * @param {string} [props.loadResolution]
+ * - which size of image should load first.
+ * - Only effective if `props.loadMode` is `'manual'`
+ * - Optional, default value is `original`
  * @returns {JSX.Element}
  */
 export default function CustomImage({
@@ -37,6 +46,8 @@ export default function CustomImage({
   width = '100%',
   height = '100%',
   debugMode = false,
+  loadMode = 'auto',
+  loadResolution = 'original',
 }) {
   const imageRef = useRef(null)
   /**
@@ -51,7 +62,7 @@ export default function CustomImage({
   }
 
   /**
-   * Transform params `images` into an array, which included four step:
+   * Transform params `images` into an array, which included three step:
    * 1. use `Object.entries` to transform object to an array, each item is an another array which item is the key and value of certain property.
    *    For example, { original: 'original.png' ,w480: 'w480.png' } will transform into [["original", "original.png"], ["w480","w480.png"] ], this array is composed of two item, each item contain two child-item.
    * 2. Check each item of array and remove it under certain conditions:
@@ -60,17 +71,14 @@ export default function CustomImage({
    *    c. the second child-item (which is the key of certain property in params `images`) is falsy values, e.g. empty string, undefined, null.
    *    As long as one of the conditions is met, will remove item.
    *    If the first child-item is "original", will not remove no matter what.
-   *
-   * 3. Sort array by the difference of first child-item. It will check the integer in first child-item, the smaller will be placed forward. If there is no integer in first child-item, it will be placed backward
-   * 4. return an array without first child-item.
-   *
+   * 3. Sort array by the difference of first child-item. It will check the integer in first child-item, the smaller will be placed forward. If there is no integer in first child-item, it will be placed backward.
    * In the end, if the params `images` is { 1600: '1600.png', original: 'original.png' ,w480: 'w480.png', w800: '', w1200: 'w1200.png' },
-   * it will return ['w480.png', 'w1200.png', 'original.png']
+   * it will return [ ['w480': 'w480.png'], ['w1200': 'w1200.png'], 'original': 'original.png']
    * @param {Object} images
-   * @returns {String[]}
+   * @returns {[string, string][]}
    */
   const transformImagesContent = (images) => {
-    /** @type {[String,String][]} */
+    /** @type {[string,string][]} */
     const imagesWithoutEmptyProperty = Object.entries(images).filter(
       (pair) => (/^w\d+$/.test(pair[0]) && pair[1]) || pair[0] === 'original'
     )
@@ -92,26 +100,110 @@ export default function CustomImage({
         return 1
       }
     })
-    return sortedImagesList.map((item) => item[1])
+    return sortedImagesList
+  }
+
+  /**
+   * Transform list of images into string for attribute 'srcset' of <img>.
+   * @param {[string, string][]} imagesList - list of images
+   */
+  const transformImagesSrcSet = (imagesList) => {
+    const str = imagesList
+      .filter((pair) => pair[0] !== 'original')
+      .map((pair) => {
+        const regex = /(\d+)/
+        const width = pair[0].match(regex)[0]
+        return `${pair[1]} ${width}w`
+      })
+      .join(',')
+    const defaultSrc = imagesList
+      .filter((pair) => pair[0] === 'original')
+      .map((pair) => `${pair[1]}`)
+    return `${str}, ${defaultSrc}`
   }
 
   const imagesList = transformImagesContent(images)
 
+  const imageSrcSet = transformImagesSrcSet(imagesList)
+
   /**
-   * print log when `props.debugMode` is true
+   * Print log when `props.debugMode` is true
    * @param {String} message
    * @returns {void}
    */
-  const printLogInDevMode = useCallback(
-    (message) => {
-      if (debugMode) {
-        console.log(message)
-      }
-    },
-    [debugMode]
-  )
+  const printLogInDevMode = (message) => {
+    if (debugMode) {
+      console.log(message)
+    }
+  }
+
   /**
-   * Loads an image and return the URL of image
+   * Check which image should be load first, and return the resolution of image.
+   * This function will act differently according to value of `loadMode`:
+   *
+   * 1. `loadMode` is "auto":
+   *    - This function check which url of image should be loaded according to the screen width.
+   *    - If loaded successfully, then return the resolution of image, such as 'w480', 'w800', 'original'.
+   *    - If not, then return the resolution of image with larger size.
+   * 2. `loadMode` is "manual":
+   *    - If `loadResolution` is not falsy and existed in item of `imagesList`, will return `loadResolution`.
+   *    - If `loadResolution` is falsy or not existed in item of `imagesList`, will return the smallest resolution in `imagesList`.
+   * @param {[string, string][]} imagesList - The URL of the images to load
+   * @returns {Promise<string>} - the resolution of image should be loaded
+   */
+  const getResolution = (imagesList) => {
+    switch (loadMode) {
+      case 'auto':
+        return new Promise((resolve, reject) => {
+          const img = new Image()
+          /**
+           * @param {Event & { target: HTMLImageElement }} event
+           */
+          const eventHandler = (event) => {
+            const eventType = event.type
+            const imageSrc = event.target?.currentSrc
+            const index = imagesList.findIndex((p) => p[1] === imageSrc)
+            if (index === -1) {
+              reject()
+            } else if (index < imagesList.length) {
+              switch (eventType) {
+                case 'load':
+                  resolve(imagesList[index][0])
+                  break
+                case 'error':
+                  resolve(imagesList[index + 1][0])
+              }
+            } else {
+              resolve(imagesList[imagesList.length - 1][0])
+            }
+
+            img.removeEventListener('load', eventHandler)
+            img.removeEventListener('error', eventHandler)
+          }
+
+          img.addEventListener('load', eventHandler)
+          img.addEventListener('error', eventHandler)
+
+          img.srcset = imageSrcSet
+        })
+
+      case 'manual':
+        return new Promise((resolve) => {
+          const isResolutionExisted = imagesList.find(
+            (pair) => pair[0] === loadResolution
+          )
+
+          if (loadResolution && isResolutionExisted) {
+            resolve(loadResolution)
+          } else {
+            resolve(imagesList[0][0])
+          }
+        })
+    }
+  }
+
+  /**
+   * Load an image and return the URL of image
    * @param {String} url - The URL of the image to load
    * @returns {Promise<String>} - The URL of the image
    */
@@ -130,49 +222,56 @@ export default function CustomImage({
 
       img.addEventListener('load', loadHandler)
       img.addEventListener('error', errorHandler)
-
       img.src = url
     })
   }
 
-  const loadImages = useCallback(
-    /**
-     * Loads a list of images in sequence
-     * If previous promise is resolved, will end the promise chain, and return URL of image
-     * If previous promise is rejected, will execute next promise
-     * @param {String[]} imageUrls - The list of image URLs to load
-     * @returns {Promise<String>} The URL of the image
-     */
-    (imageUrls) => {
-      return imageUrls.reduce((prevPromise, url) => {
-        return prevPromise.catch(() => loadImage(url))
-      }, Promise.reject())
-    },
-    []
-  )
+  /**
+   * Loads a list of images in sequence, it will start loading on certain resolution.
+   * If previous promise is resolved, will end the promise chain, and return URL of image which successfully loaded.
+   * If previous promise is rejected, will execute next promise
+   * @param {string} resolution - The resolution determine which URL of image should loaded first.
+   * @returns {Promise<string>} - The URL of the image should loaded
+   */
+  const loadImages = (resolution) => {
+    const index = imagesList.findIndex((pair) => pair[0] === resolution)
+    const loadList = imagesList.slice(index)
+    return loadList.reduce((prevPromise, pair) => {
+      return prevPromise.catch(() => loadImage(pair[1]))
+    }, Promise.reject())
+  }
 
   useEffect(() => {
     try {
       let callback = (entries, observer) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            loadImages(imagesList)
-              .then((imageUrl) => {
-                imageRef.current.src = imageUrl
-                printLogInDevMode(
-                  `Successfully Load image, current image source is ${imageUrl}`
-                )
+            getResolution(imagesList)
+              .then((resolution) => {
+                loadImages(resolution)
+                  .then((url) => {
+                    imageRef.current.src = url
+                    printLogInDevMode(
+                      `Successfully Load image, current image source is ${url}`
+                    )
+                  })
+                  .catch(() => {
+                    imageRef.current.src = defaultImage
+                    printLogInDevMode(
+                      'Unable to load any image, try to use default image as image src'
+                    )
+                    imageRef.current.addEventListener('error', () => {
+                      printLogInDevMode('Unable to load default image')
+                    })
+                  })
               })
               .catch(() => {
-                printLogInDevMode(
-                  'Unable to load any image , try to use default image as image src'
-                )
-
                 imageRef.current.src = defaultImage
-                imageRef.current.addEventListener('error', () => {
-                  printLogInDevMode('Unable to load default image')
-                })
+                printLogInDevMode(
+                  'Unable to get resolution, try to use default image as image src'
+                )
               })
+
             imageRef.current.style.filter = 'unset'
             observer.unobserve(entry.target)
           }
@@ -192,7 +291,7 @@ export default function CustomImage({
       imageRef.current.style.visibility = 'hidden'
       console.error(`Unhandled error happened, hide image element', ${err}`)
     }
-  }, [imagesList, loadImages, defaultImage, printLogInDevMode])
+  }, [imagesList, defaultImage, printLogInDevMode])
 
   return (
     <img


### PR DESCRIPTION

## Notable change:
 1. Change package name a3a3cf0 : 發現之前套件的名稱取錯的，應為`<framework>-<package name>`，故修改為`react-image`。待PR merge 後，會發布新的套件，舊有的套件會deprecated
 2. Add image load mode bd87819 : 新增新功能，元件可選擇兩種圖片模式`"auto"`、`"manual"`，若為`"auto"`，則會依據螢幕寬度自動載入最合適大小的圖片；若為`"manual"`，則會依據使用者指定的大小載入圖片。
 3. [3518edf](https://github.com/readr-media/react/pull/117/commits/3518edf214b151560c8a4d5f9ef8e3164afb0880): update README.md


## Detail of commit bd87819
1. 元件新增參數`loadMode`，預設為`"auto"`。
2. 元件新增參數`loadResolution`，預設為`"original"`。
4. 調整函式 `transformImagesContent()`回傳的資料結構。
5. 新增函式 `transformImagesSrcSet()`，用於計算變數`imageSrcSet`。
6. 新增函式`getResolution()`，用於取得需要載入的圖片尺寸：
   - 如果`loadMode`為`"auto"`，則會透過`new Image()`搭配 `img.srcset = imageSrcSet`，取得在目前螢幕寬度下，最適合載入的圖片url。如果載入成功，則回傳該url對應的解析度；如果載入失敗，則回傳更大尺寸圖片url對應的解析度。
   -  如果`loadMode`為`"manual"`，則會依據`loadResolution`的值，回傳對應的解析度。
   - 檢查條件「`loadResolution`不為falsy且存在於imageList」，如果符合該條件，則回傳`loadResolution`，否則則回傳最小尺寸圖片的解析度。
7. 取得`getResolution()`所回傳的解析度，並於函式[`loadImages`](https://github.com/readr-media/react/pull/117/files#diff-3f61a8623e00f087b70b1018dd42536c8ed7ae5df4614c87ca20119dad24d64dR251)依據解析度載入圖片。
8. 函式loadImage以及函式loadImages組成Promise chain：當一圖片URL載入失敗後，則嘗試載入下一圖片URL，當一圖片URL載入成功後，則停止嘗試載入。
9. 如果所有圖片URL載入失敗後，則[將`<img>`的src設為預設圖片](https://github.com/readr-media/react/pull/117/files#diff-3f61a8623e00f087b70b1018dd42536c8ed7ae5df4614c87ca20119dad24d64dR259)
