### PR TITLE
refactor(image): fix image path with special characters

### DIFF
--- a/packages/image/CHANGELOG.md
+++ b/packages/image/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @readr-media/react-image Changelog
 
+## 2023-03-17, Version 1.5.0
+
+### Notable Changes
+- fix issue that image path with special characters doesn't load
+
+### Commits
+* \[[`a910b6ba73`](https://github.com/readr-media/react-image/commit/a910b6ba73)] - chore(image): bump version to 1.5.0 (Tsuki Akiba)
+* \[[`6c840c12d2`](https://github.com/readr-media/react-image/commit/6c840c12d2)] - refactor(image): fix image path with special characters (Tsuki Akiba)
+* \[[`273c165155`](https://github.com/readr-media/react-image/commit/273c165155)] - docs(image): update CHANGELOG.md (Tsuki Akiba)
+
 ## 2023-03-17, Version 1.4.2
 
 ### Notable Changes

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-image",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "",
   "main": "lib/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,8 @@
   },
   "files": [
     "lib",
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "devDependencies": {
     "@types/node": "^18.15.3",

--- a/packages/image/src/react-components/index.js
+++ b/packages/image/src/react-components/index.js
@@ -160,7 +160,7 @@ export default function CustomImage({
       .filter((pair) => pair[0] !== 'original')
       .map((pair) => {
         const width = pair[0].match(REGEX)[0]
-        return `${pair[1]} ${width}w`
+        return `${encodeURI(pair[1])} ${width}w`
       })
       .join(',')
     return str


### PR DESCRIPTION
## 更新內容
* 修正圖片連結帶有特殊字元的情況下，圖片不會載入的問題

## 備註
* 圖片連結帶有特殊字元，如：空白，會導致產生出來的 `srcSet` 格式不正確，使得圖片無法被載入，因此需要使用 `encodeURI` 來進行處理，避免這類問題