### PR TITLE
refactor(image): fix image path with special characters

### DIFF
--- a/packages/image/CHANGELOG.md
+++ b/packages/image/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @readr-media/react-image Changelog
 
+## 2023-03-17, Version 1.5.1
+
+### Notable Changes
+- fix issue that image path with special characters doesn't load
+
+### Commits
+* \[[`67e8c38463`](https://github.com/readr-media/react-image/commit/67e8c38463)] - chore(image): bump version to 1.5.1 (Tsuki Akiba)
+* \[[`1c4e52c12b`](https://github.com/readr-media/react-image/commit/1c4e52c12b)] - refactor(image): fix image path with special characters (Tsuki Akiba)
+* \[[`43bb7e6feb`](https://github.com/readr-media/react-image/commit/43bb7e6feb)] - docs(image): update CHANGELOG (Tsuki Akiba)
+* \[[`e6a7109524`](https://github.com/readr-media/react-image/commit/e6a7109524)] - chore(image): bump version to 1.5.0 (Tsuki Akiba)
+* 
 ## 2023-03-17, Version 1.5.0
 
 ### Notable Changes

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-image",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "main": "lib/index.js",
   "types": "dist/index.d.ts",

--- a/packages/image/src/react-components/index.js
+++ b/packages/image/src/react-components/index.js
@@ -128,9 +128,11 @@ export default function CustomImage({
    */
   const transformImagesContent = (images) => {
     /** @type {[string,string][]} */
-    const imagesWithoutEmptyProperty = Object.entries(images).filter(
-      (pair) => (/^w\d+$/.test(pair[0]) && pair[1]) || pair[0] === 'original'
-    )
+    const imagesWithoutEmptyProperty = Object.entries(images)
+      .filter(
+        (pair) => (/^w\d+$/.test(pair[0]) && pair[1]) || pair[0] === 'original'
+      )
+      .map(([key, value]) => [key, encodeURI(value)])
     const sortedImagesList = imagesWithoutEmptyProperty.sort((pairA, pairB) => {
       // pair: [w800, image-w800.jpg], [original, image.jpg]
       const keyA = pairA[0]
@@ -160,7 +162,7 @@ export default function CustomImage({
       .filter((pair) => pair[0] !== 'original')
       .map((pair) => {
         const width = pair[0].match(REGEX)[0]
-        return `${encodeURI(pair[1])} ${width}w`
+        return `${pair[1]} ${width}w`
       })
       .join(',')
     return str


### PR DESCRIPTION
## 更新內容
* 修正圖片連結帶有特殊字元的情況下，圖片不會載入的問題

## 備註
* 續 https://github.com/readr-media/react/pull/148#issuecomment-1475668435 ，調整圖片連結處理方式，從源頭處理的 `transformImagesContent` 中套用 `encodeURI`