### PR TITLE
refactor(timeline): update timeline with react-virtualized

### DIFF
--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-embed-code-generator",
-  "version": "2.4.0-alpha.41",
+  "version": "2.4.1-alpha.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "@readr-media/react-random-text-selector": "^1.0.2",
     "@readr-media/react-theatre": "^1.1.0",
     "@readr-media/react-three-story-points": "1.0.2",
-    "@readr-media/react-timeline": "^1.0.0-alpha.24",
+    "@readr-media/react-timeline": "1.1.0-alpha.1",
     "lodash": "^4.17.21",
     "serialize-javascript": "^6.0.0"
   },
@@ -50,7 +50,7 @@
     "@babel/eslint-parser": "^7.11.4",
     "@babel/preset-env": "^7.17.12",
     "@babel/preset-react": "^7.17.12",
-    "@readr-media/react-embed-code-generator": "2.4.0-alpha.40",
+    "@readr-media/react-embed-code-generator": "2.4.1-alpha.1",
     "@svgr/webpack": "^6.2.1",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.5",

--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-embed-code-generator",
-  "version": "2.4.0-alpha.39",
+  "version": "2.4.0-alpha.41",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "@readr-media/react-random-text-selector": "^1.0.2",
     "@readr-media/react-theatre": "^1.1.0",
     "@readr-media/react-three-story-points": "1.0.2",
-    "@readr-media/react-timeline": "^1.0.0-alpha.23",
+    "@readr-media/react-timeline": "^1.0.0-alpha.24",
     "lodash": "^4.17.21",
     "serialize-javascript": "^6.0.0"
   },
@@ -50,7 +50,7 @@
     "@babel/eslint-parser": "^7.11.4",
     "@babel/preset-env": "^7.17.12",
     "@babel/preset-react": "^7.17.12",
-    "@readr-media/react-embed-code-generator": "2.4.0-alpha.39",
+    "@readr-media/react-embed-code-generator": "2.4.0-alpha.40",
     "@svgr/webpack": "^6.2.1",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.5",

--- a/packages/embed-code-generator/yarn.lock
+++ b/packages/embed-code-generator/yarn.lock
@@ -993,6 +993,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.7.2":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
+  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -1178,10 +1185,10 @@
     "@twreporter/errors" "^1.1.1"
     axios "^0.27.2"
 
-"@readr-media/react-embed-code-generator@2.4.0-alpha.39":
-  version "2.4.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-embed-code-generator/-/react-embed-code-generator-2.4.0-alpha.39.tgz#ca527febff120685fcaf89ed2b3e76949f359470"
-  integrity sha512-xBRGEBK4HlALDUkKzU6RRr5nPAzs2PD5eN6jO9ii/AMzlMqlRIgGi1x0GotQLz9rx5CPteXMXoIKQZ6LprAbzQ==
+"@readr-media/react-embed-code-generator@2.4.0-alpha.40":
+  version "2.4.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-embed-code-generator/-/react-embed-code-generator-2.4.0-alpha.40.tgz#a8b915bd992a418bc90a906abf8d966b91b7609b"
+  integrity sha512-LSv99+xkqzb4OFh0QPRyeYn0UArb0WmwH86YsehcYxCmAQBC5ZAJE2RmTRPbg9ryjsq+Y7Dzch1VNTScgN93tA==
   dependencies:
     "@readr-media/react-dropping-text" "1.0.6"
     "@readr-media/react-dual-slides" "1.0.1"
@@ -1195,7 +1202,7 @@
     "@readr-media/react-random-text-selector" "^1.0.2"
     "@readr-media/react-theatre" "^1.1.0"
     "@readr-media/react-three-story-points" "1.0.2"
-    "@readr-media/react-timeline" "^1.0.0-alpha.23"
+    "@readr-media/react-timeline" "^1.0.0-alpha.24"
     lodash "^4.17.21"
     serialize-javascript "^6.0.0"
 
@@ -1297,13 +1304,14 @@
     three "^0.150.1"
     three-story-controls "^1.0.6"
 
-"@readr-media/react-timeline@^1.0.0-alpha.23":
-  version "1.0.0-alpha.23"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-timeline/-/react-timeline-1.0.0-alpha.23.tgz#39e76d2e14a627c78a14009abe900394485ed18d"
-  integrity sha512-dJoQTO+RszH7G7HAGa5SECIRO7XWOQAb/hJNiwrz0Uk99XpivKTRGitdzAwlgt8bs18RLJ5iMvixcgdaWi9MHw==
+"@readr-media/react-timeline@^1.0.0-alpha.24":
+  version "1.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-timeline/-/react-timeline-1.0.0-alpha.24.tgz#a16609b5a4cc024918bd059053cf51f35140f08f"
+  integrity sha512-Xou4LIcr0h5ABYyOhUiRYG1ZoeyMugzMtYQwlGnvg8FEpmFTYp05JPkio93GkH4K3O2cfvwmfFTjSadUQxUCQA==
   dependencies:
     axios "^0.27.2"
     draft-js "^0.11.7"
+    react-virtualized "^9.22.4"
 
 "@svgr/babel-plugin-add-jsx-attribute@^6.5.1":
   version "6.5.1"
@@ -2247,6 +2255,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clsx@^1.0.4:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -2571,7 +2584,7 @@ dom-converter@^0.2.0:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^5.0.1:
+dom-helpers@^5.0.1, dom-helpers@^5.1.3:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
   integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
@@ -4470,7 +4483,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -4564,6 +4577,11 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
@@ -4573,6 +4591,18 @@ react-transition-group@^4.4.5:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-virtualized@^9.22.4:
+  version "9.22.5"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.5.tgz#bfb96fed519de378b50d8c0064b92994b3b91620"
+  integrity sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    clsx "^1.0.4"
+    dom-helpers "^5.1.3"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-lifecycles-compat "^3.0.4"
 
 react@18.1.0:
   version "18.1.0"
@@ -4633,6 +4663,11 @@ regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.9:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regenerator-transform@^0.15.1:
   version "0.15.1"

--- a/packages/embed-code-generator/yarn.lock
+++ b/packages/embed-code-generator/yarn.lock
@@ -1185,10 +1185,10 @@
     "@twreporter/errors" "^1.1.1"
     axios "^0.27.2"
 
-"@readr-media/react-embed-code-generator@2.4.0-alpha.40":
-  version "2.4.0-alpha.40"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-embed-code-generator/-/react-embed-code-generator-2.4.0-alpha.40.tgz#a8b915bd992a418bc90a906abf8d966b91b7609b"
-  integrity sha512-LSv99+xkqzb4OFh0QPRyeYn0UArb0WmwH86YsehcYxCmAQBC5ZAJE2RmTRPbg9ryjsq+Y7Dzch1VNTScgN93tA==
+"@readr-media/react-embed-code-generator@2.4.1-alpha.1":
+  version "2.4.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-embed-code-generator/-/react-embed-code-generator-2.4.1-alpha.1.tgz#dd30faedb6d1cdef2adad7682449ddd982d6242a"
+  integrity sha512-UNF26Ab/yaNulKEp+00kew+CF6r75roIunp5eLHGwrwPdnwRLKHLOfUVbj61AE8Ro48bu2cAxjqlpG0KtEQklQ==
   dependencies:
     "@readr-media/react-dropping-text" "1.0.6"
     "@readr-media/react-dual-slides" "1.0.1"
@@ -1202,7 +1202,7 @@
     "@readr-media/react-random-text-selector" "^1.0.2"
     "@readr-media/react-theatre" "^1.1.0"
     "@readr-media/react-three-story-points" "1.0.2"
-    "@readr-media/react-timeline" "^1.0.0-alpha.24"
+    "@readr-media/react-timeline" "1.1.0-alpha.1"
     lodash "^4.17.21"
     serialize-javascript "^6.0.0"
 
@@ -1304,10 +1304,10 @@
     three "^0.150.1"
     three-story-controls "^1.0.6"
 
-"@readr-media/react-timeline@^1.0.0-alpha.24":
-  version "1.0.0-alpha.24"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-timeline/-/react-timeline-1.0.0-alpha.24.tgz#a16609b5a4cc024918bd059053cf51f35140f08f"
-  integrity sha512-Xou4LIcr0h5ABYyOhUiRYG1ZoeyMugzMtYQwlGnvg8FEpmFTYp05JPkio93GkH4K3O2cfvwmfFTjSadUQxUCQA==
+"@readr-media/react-timeline@1.1.0-alpha.1":
+  version "1.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-timeline/-/react-timeline-1.1.0-alpha.1.tgz#9b8d16b202dfedbcd08a2cda0c145586a6a58527"
+  integrity sha512-3yNI+DZuJmEAs7mIZJXt4qCHTE8KQqSD01XV1y099BhIpiyzhnN14qGMsMYBHlRd2Zx2a7S62uh2bKwH3ZyVUg==
   dependencies:
     axios "^0.27.2"
     draft-js "^0.11.7"

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -23,7 +23,8 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.27.2",
-    "draft-js": "^0.11.7"
+    "draft-js": "^0.11.7",
+    "react-window": "^1.8.9"
   },
   "peerDependencies": {
     "react": "18.1.0",

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "draft-js": "^0.11.7",
-    "react-window": "^1.8.9"
+    "react-virtualized": "^9.22.4"
   },
   "peerDependencies": {
     "react": "18.1.0",

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-timeline",
-  "version": "1.0.0-alpha.23",
+  "version": "1.0.0-alpha.24",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-timeline",
-  "version": "1.0.0-alpha.24",
+  "version": "1.1.0-alpha.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/timeline/src/react-components/index.js
+++ b/packages/timeline/src/react-components/index.js
@@ -56,6 +56,9 @@ const Wrapper = styled.div`
   background-color: #efefef;
   overflow: hidden;
   width: 100vw;
+  height: calc(
+    100vh - ${({ headerHeight }) => (headerHeight ? headerHeight : '0px')}
+  );
   position: relative;
   left: calc(50% - 50vw);
 `
@@ -319,7 +322,7 @@ export default function Timeline({
     )
   return (
     <TagsContext.Provider value={{ tags, addTag, removeTag }}>
-      <Wrapper>
+      <Wrapper headerHeight={headerHeight}>
         <TimelineWrapper>
           <div id="top" />
           <GlobalStyles />

--- a/packages/timeline/src/react-components/index.js
+++ b/packages/timeline/src/react-components/index.js
@@ -1,4 +1,4 @@
-import styled, { createGlobalStyle } from 'styled-components'
+import styled from 'styled-components'
 import {
   calcNextLevelUnitKey,
   generateTimeLevel,
@@ -15,12 +15,21 @@ import { defaultConifg } from '../const/config'
 import { useTimelineConfig } from './hook/useTimelineConfig'
 import TimelineList from './timeline-list'
 
-const GlobalStyles = createGlobalStyle`
+const Wrapper = styled.div`
+  background-color: #efefef;
+  overflow: hidden;
+  width: 100vw;
+  height: calc(
+    100vh - ${({ headerHeight }) => (headerHeight ? headerHeight : '0px')}
+  );
+  position: relative;
+  left: calc(50% - 50vw);
+
+  // reset for Timeline only
   * {
     box-sizing: border-box;
     font-family: Noto Sans CJK TC;
     -webkit-tap-highlight-color: transparent;
-
   }
 
   button {
@@ -50,17 +59,6 @@ const GlobalStyles = createGlobalStyle`
   figure {
     margin: 0;
   }
-`
-
-const Wrapper = styled.div`
-  background-color: #efefef;
-  overflow: hidden;
-  width: 100vw;
-  height: calc(
-    100vh - ${({ headerHeight }) => (headerHeight ? headerHeight : '0px')}
-  );
-  position: relative;
-  left: calc(50% - 50vw);
 `
 
 const TimelineWrapper = styled.div`
@@ -324,8 +322,6 @@ export default function Timeline({
     <TagsContext.Provider value={{ tags, addTag, removeTag }}>
       <Wrapper headerHeight={headerHeight}>
         <TimelineWrapper>
-          <div id="top" />
-          <GlobalStyles />
           <TimelineNodesWrapper
             ref={containerRef}
             eventMode={measure === 'event'}
@@ -355,7 +351,6 @@ export default function Timeline({
               }}
             />
           )}
-          <div id="bottom" />
         </TimelineWrapper>
       </Wrapper>
     </TagsContext.Provider>

--- a/packages/timeline/src/react-components/index.js
+++ b/packages/timeline/src/react-components/index.js
@@ -102,7 +102,6 @@ export default function Timeline({
     [liveblog, isTimeSortedAsc]
   )
   const [tags, setTags] = useState(initialTags)
-  const [stickyStrategy, setStickStrategy] = useState('absolute-top')
   const [focusUnitKey, setFocusUnitKey] = useState('')
 
   const timelineConfig = timeline.config || defaultConifg
@@ -182,22 +181,6 @@ export default function Timeline({
       let focusNode = containerDiv.children[index]
       let newFocusUnitKey = focusNode.id.split('-')[1]
       setFocusUnitKey(newFocusUnitKey)
-
-      // count sticky policy together with onscroll
-      const bounding = containerRef.current.getBoundingClientRect()
-      if (bounding.height < window.innerHeight) {
-        setStickStrategy('absolute')
-        return
-      }
-      if (bounding.height) {
-        if (bounding.y >= headerHeight) {
-          setStickStrategy('absolute-top')
-        } else if (bounding.y + bounding.height > window.innerHeight) {
-          setStickStrategy('fixed')
-        } else {
-          setStickStrategy('absolute-bottom')
-        }
-      }
     }
     window.addEventListener('scroll', onScroll)
 
@@ -350,7 +333,6 @@ export default function Timeline({
             maxLevel={maxLevel}
             level={level}
             updateLevel={updateLevel}
-            stickyStrategy={stickyStrategy}
             selectedTags={tags}
             allTags={allTags}
             headerHeight={headerHeight}
@@ -359,7 +341,6 @@ export default function Timeline({
             <TimelineEventPanel
               event={focusEvent}
               fetchImageBaseUrl={fetchImageBaseUrl}
-              stickyStrategy={stickyStrategy}
               timeUnitKey={focusUnitKey}
               headerHeight={headerHeight}
               timeUnitKeys={timeUnitKeys}

--- a/packages/timeline/src/react-components/index.js
+++ b/packages/timeline/src/react-components/index.js
@@ -1,5 +1,4 @@
 import styled, { createGlobalStyle } from 'styled-components'
-import TimelineUnit from './timeline-unit'
 import {
   calcNextLevelUnitKey,
   generateTimeLevel,
@@ -14,6 +13,7 @@ import TimelineEvent from './timeline-event'
 import { TagsContext, initialTags } from './useTags'
 import { defaultConifg } from '../const/config'
 import { useTimelineConfig } from './hook/useTimelineConfig'
+import TimelineList from './timeline-list'
 
 const GlobalStyles = createGlobalStyle`
   * {
@@ -85,11 +85,6 @@ const EventWrapper = styled.div`
     margin: 12px auto 0;
   }
 `
-
-function getBubbleLevel(max, count) {
-  const levelSize = max / 5
-  return Math.ceil(count / levelSize) - 1
-}
 
 /**
  * @param {Object} props
@@ -306,45 +301,39 @@ export default function Timeline({
       : null
 
   let timelineNodesJsx =
-    measure !== 'event'
-      ? timeUnitKeysToRender.map((timeUnitKey, i) => {
-          const events = timeUnitEvents[timeUnitKey] || []
-          return (
-            <TimelineUnit
-              eventsCount={events.length}
-              bubbleSizeLevel={getBubbleLevel(timeMax, events.length)}
-              dividers={dividers}
-              bubbleLevelSizesInDivider={bubbleLevelSizesInDivider}
-              key={timeUnitKey + i}
-              onBubbleClick={() => {
-                updateLevel(level - 1, timeUnitKey)
-              }}
-              onSingleTimelineNodeSelect={() => {
-                setFocusUnitKey(timeUnitKey)
-              }}
-              isFocus={timeUnitKey === focusUnitKey}
-              headerHeight={headerHeight}
-              measure={measure}
+    measure !== 'event' ? (
+      <TimelineList
+        timeUnitKeys={timeUnitKeysToRender}
+        timeUnitEvents={timeUnitEvents}
+        timeMax={timeMax}
+        dividers={dividers}
+        bubbleLevelSizesInDivider={bubbleLevelSizesInDivider}
+        onBubbleClick={(timeUnitKey) => {
+          updateLevel(level - 1, timeUnitKey)
+        }}
+        onSingleTimelineNodeSelect={(timeUnitKey) => {
+          setFocusUnitKey(timeUnitKey)
+        }}
+        focusUnitKey={focusUnitKey}
+        headerHeight={headerHeight}
+        measure={measure}
+        firstTimeUnitKey={firstTimeUnitKey}
+        lastTimeeUnitKey={lastTimeeUnitKey}
+      />
+    ) : (
+      timeUnitKeysToRender.map((timeUnitKey) => {
+        const event = timeUnitEvents[timeUnitKey]
+        return (
+          <EventWrapper key={timeUnitKey} id={`node-${timeUnitKey}`}>
+            <TimelineEvent
+              event={event}
+              fetchImageBaseUrl={fetchImageBaseUrl}
               timeUnitKey={timeUnitKey}
-              isTheFirstOrLastUnit={
-                timeUnitKey === firstTimeUnitKey ||
-                timeUnitKey === lastTimeeUnitKey
-              }
             />
-          )
-        })
-      : timeUnitKeysToRender.map((timeUnitKey) => {
-          const event = timeUnitEvents[timeUnitKey]
-          return (
-            <EventWrapper key={timeUnitKey} id={`node-${timeUnitKey}`}>
-              <TimelineEvent
-                event={event}
-                fetchImageBaseUrl={fetchImageBaseUrl}
-                timeUnitKey={timeUnitKey}
-              />
-            </EventWrapper>
-          )
-        })
+          </EventWrapper>
+        )
+      })
+    )
   return (
     <TagsContext.Provider value={{ tags, addTag, removeTag }}>
       <Wrapper>

--- a/packages/timeline/src/react-components/index.js
+++ b/packages/timeline/src/react-components/index.js
@@ -84,6 +84,9 @@ const TimelineNodesWrapper = styled.div`
     }
   }
   overflow: hidden auto;
+  position: relative;
+  width: 100vw;
+  left: calc(50% - 50vw);
   ${({ height }) => height && `height: ${height}px;`}
   ${({ eventMode }) => eventMode && `padding: 0 36px 12px;`}
 `
@@ -147,8 +150,11 @@ export default function Timeline({
   const lastTimeUnitKeyToRender =
     timeUnitKeysToRender[timeUnitKeysToRender.length - 1]
   const divider = dividers[measure]
-  const [listHeight, setListHeight] = useState(800)
-  const listItemHeight = listHeight / divider
+  const [listDimemsion, setListDimemsion] = useState({
+    width: 320,
+    height: 800,
+  })
+  const listItemHeight = listDimemsion.height / divider
 
   /** @type {React.RefObject<HTMLDivElement>} */
   const containerRef = useRef(null)
@@ -173,7 +179,17 @@ export default function Timeline({
   }
 
   useEffect(() => {
-    setListHeight(window.innerHeight - headerHeight)
+    const resizeHandler = () => {
+      setListDimemsion({
+        width: window.innerWidth,
+        height: window.innerHeight - headerHeight,
+      })
+    }
+    window.addEventListener('resize', resizeHandler)
+    resizeHandler()
+    return () => {
+      window.removeEventListener('resize', resizeHandler)
+    }
   }, [headerHeight])
 
   // handle event mode updating focusUnitKey when user scrolling
@@ -408,7 +424,7 @@ export default function Timeline({
         measure={measure}
         firstTimeUnitKey={firstTimeUnitKeyToRender}
         lastTimeUnitKey={lastTimeUnitKeyToRender}
-        listHeight={listHeight}
+        listDimemsion={listDimemsion}
         listItemHeight={listItemHeight}
         onTimelineListScroll={onTimelineListScroll}
       />
@@ -434,7 +450,7 @@ export default function Timeline({
             id="containerRef"
             ref={containerRef}
             eventMode={measure === 'event'}
-            height={listHeight}
+            height={listDimemsion.height}
           >
             {timelineNodesJsx}
           </TimelineNodesWrapper>

--- a/packages/timeline/src/react-components/index.js
+++ b/packages/timeline/src/react-components/index.js
@@ -142,9 +142,10 @@ export default function Timeline({
   const measure = getMeasureFromLevel(level)
   const timeUnitEvents = timeEvents[measure]
   const timeUnitKeys = timeKeys[measure]
-  const firstTimeUnitKeyToRender = timeKeysToRender[0]
-  const lastTimeUnitKeyToRender = timeKeysToRender[timeKeysToRender.length - 1]
   const timeUnitKeysToRender = timeKeysToRender[measure]
+  const firstTimeUnitKeyToRender = timeUnitKeysToRender[0]
+  const lastTimeUnitKeyToRender =
+    timeUnitKeysToRender[timeUnitKeysToRender.length - 1]
   const divider = dividers[measure]
   const [listHeight, setListHeight] = useState(800)
   const listItemHeight = listHeight / divider

--- a/packages/timeline/src/react-components/index.js
+++ b/packages/timeline/src/react-components/index.js
@@ -74,6 +74,15 @@ const TimelineWrapper = styled.div`
 `
 
 const TimelineNodesWrapper = styled.div`
+  // hide react-virtualized List scrollbar
+  & > div {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+    &::-webkit-scrollbar {
+      display: none; /* for Chrome, Safari and Opera */
+    }
+  }
+
   ${({ eventMode }) => eventMode && `padding: 0 36px 12px;`}
 `
 

--- a/packages/timeline/src/react-components/timeline-control.js
+++ b/packages/timeline/src/react-components/timeline-control.js
@@ -8,43 +8,12 @@ const Wrapper = styled.div`
   padding-bottom: 4px;
   display: flex;
   flex-direction: column;
-  ${({ stickyStrategy, headerHeight }) => {
-    switch (stickyStrategy) {
-      case 'absolute':
-        return `
-          position: absolute;
-          bottom: 0;
-        `
-      case 'fixed':
-        return `
-          position: fixed;
-          bottom: 0;
-        `
-      case 'absolute-top':
-        return `
-          position: absolute;
-          top: calc(100vh - ${headerHeight}px - 20px - 84px);
-        `
-      case 'absolute-bottom':
-      default:
-        return `
-        position: absolute;
-        bottom: 0;
-
-      `
-    }
-  }}
+  position: absolute;
+  bottom: 0;
   z-index: 10;
 
   @media (min-width: 768px) {
     left: 170px;
-  }
-  @media (min-width: 1200px) {
-    ${({ stickyStrategy }) =>
-      stickyStrategy === 'fixed' &&
-      `
-        left: calc((100vw - 1200px)/2 + 170px);
-      `}
   }
 `
 
@@ -90,37 +59,10 @@ const PcTagsControl = styled.div`
   @media (min-width: 768px) {
     pointer-events: none;
     display: block;
-    margin: 20px 0 0 24px;
-    ${({ stickyStrategy, headerHeight }) => {
-      switch (stickyStrategy) {
-        case 'absolute':
-          return `
-            position: absolute;
-            top: 0px;
-            height: calc(100vh - ${headerHeight}px);
-          `
-        case 'fixed':
-          return `
-            position: fixed;
-            top: ${headerHeight}px;
-            height: calc(100vh - ${headerHeight}px);
-          `
-        case 'absolute-top':
-          return `
-            position: absolute;
-            top: 0;
-            height: calc(100vh - ${headerHeight}px);
-          `
-        case 'absolute-bottom':
-        default:
-          return `
-          position: absolute;
-          bottom: 0;
-          height: calc(100vh - ${headerHeight}px);
-
-        `
-      }
-    }}
+    margin-left: 24px;
+    position: absolute;
+    top: 20px;
+    height: calc(100% - 20px);
   }
 `
 
@@ -185,7 +127,6 @@ export default function TimelineControl({
   maxLevel,
   level,
   updateLevel,
-  stickyStrategy,
   selectedTags,
   headerHeight,
   allTags,
@@ -196,7 +137,7 @@ export default function TimelineControl({
 
   return (
     <>
-      <Wrapper stickyStrategy={stickyStrategy} headerHeight={headerHeight}>
+      <Wrapper headerHeight={headerHeight}>
         <LevelControl>
           <LevelControlTopButton
             onClick={() => {
@@ -236,10 +177,7 @@ export default function TimelineControl({
           </MobileTagsControl>
         )}
       </Wrapper>
-      <PcTagsControl
-        stickyStrategy={stickyStrategy}
-        headerHeight={headerHeight}
-      >
+      <PcTagsControl headerHeight={headerHeight}>
         {allTags.map((tag) => {
           const selected = selectedTags.includes(tag)
           return (

--- a/packages/timeline/src/react-components/timeline-event-header.js
+++ b/packages/timeline/src/react-components/timeline-event-header.js
@@ -19,10 +19,6 @@ const Category = styled.span`
   line-height: 14px;
   margin-right: 8px;
   color: #999;
-  pointer-events: none;
-  @media (min-width: 768px) {
-    pointer-events: auto;
-  }
 `
 
 const PublishInfoWrapper = styled.div`

--- a/packages/timeline/src/react-components/timeline-event-panel.js
+++ b/packages/timeline/src/react-components/timeline-event-panel.js
@@ -17,33 +17,11 @@ const Wrapper = styled.div`
   align-items: center;
   z-index: 10;
   border-radius: 4px;
-
-  ${({ stickyStrategy, headerHeight }) => {
-    switch (stickyStrategy) {
-      case 'absolute':
-        return `
-        position: absolute;
-        top: calc(var(--mobile-top) - ${headerHeight}px);
-        `
-      case 'fixed':
-        return `
-          position: fixed;
-          top: var(--mobile-top);
-          right: calc((100vw - 320px) / 2 + 12px);
-        `
-      case 'absolute-bottom':
-        return `
-          position: absolute;
-          bottom: calc(100vh - var(--mobile-top) - var(--mobile-height));
-        `
-      case 'absolute-top':
-      default:
-        return `
-          position: absolute;
-          top: calc(var(--mobile-top) - ${headerHeight}px);
-        `
-    }
-  }}
+  position: absolute;
+  top: calc(
+    var(--mobile-top) -
+      ${({ headerHeight }) => (headerHeight ? headerHeight : 0)}px
+  );
 
   @media (min-width: 768px) {
     --pc-height: 527px;
@@ -52,39 +30,10 @@ const Wrapper = styled.div`
     left: 387px;
     width: 360px;
     height: var(--pc-height);
-    ${({ stickyStrategy, headerHeight }) => {
-      switch (stickyStrategy) {
-        case 'absolute':
-          return `
-          position: absolute;
-          top: calc(var(--pc-top) - ${headerHeight}px);
-          `
-        case 'fixed':
-          return `
-            position: fixed;
-            top: var(--pc-top);
-            right: calc((100vw - 320px) / 2 + 12px);
-          `
-        case 'absolute-bottom':
-          return `
-            position: absolute;
-            bottom: calc(100vh - var(--pc-top) - var(--pc-height));
-          `
-        case 'absolute-top':
-        default:
-          return `
-            position: absolute;
-            top: calc(var(--pc-top) - ${headerHeight}px);
-          `
-      }
-    }}
-  }
-  @media (min-width: 1200px) {
-    ${({ stickyStrategy }) =>
-      stickyStrategy === 'fixed' &&
-      `
-      left: calc((100vw - 1200px)/2 + 387px);
-    `}
+    top: calc(
+      var(--pc-top) -
+        ${({ headerHeight }) => (headerHeight ? headerHeight : 0)}px
+    );
   }
 `
 
@@ -130,7 +79,6 @@ const EmptyEventWrapper = styled.div`
 export default function TimelineEventPanel({
   event,
   fetchImageBaseUrl,
-  stickyStrategy,
   timeUnitKey,
   headerHeight,
   timeUnitKeys,
@@ -183,7 +131,7 @@ export default function TimelineEventPanel({
   )
 
   return (
-    <Wrapper stickyStrategy={stickyStrategy} headerHeight={headerHeight}>
+    <Wrapper headerHeight={headerHeight}>
       {panelContentJsx}
       <EventSwitchControl>
         <EventSwitchControlButton

--- a/packages/timeline/src/react-components/timeline-list.js
+++ b/packages/timeline/src/react-components/timeline-list.js
@@ -1,4 +1,6 @@
+import { FixedSizeList } from 'react-window'
 import TimelineUnit from './timeline-unit'
+import { useEffect, useRef, useState } from 'react'
 
 function getBubbleLevel(max, count) {
   const levelSize = max / 5
@@ -19,28 +21,54 @@ export default function TimelineList({
   firstTimeUnitKey,
   lastTimeeUnitKey,
 }) {
-  return timeUnitKeys.map((timeUnitKey, i) => {
+  const [listHeight, setListHeight] = useState(800)
+  const divider = dividers[measure]
+  const listItemHeight = listHeight / divider
+  const listRef = useRef(null)
+
+  useEffect(() => {
+    setListHeight(window.innerHeight - headerHeight)
+  }, [headerHeight])
+
+  const Row = ({ index, style }) => {
+    const timeUnitKey = timeUnitKeys[index]
     const events = timeUnitEvents[timeUnitKey] || []
+    const i = index
+
     return (
-      <TimelineUnit
-        eventsCount={events.length}
-        bubbleSizeLevel={getBubbleLevel(timeMax, events.length)}
-        dividers={dividers}
-        bubbleLevelSizesInDivider={bubbleLevelSizesInDivider}
-        key={timeUnitKey + i}
-        onBubbleClick={onBubbleClick.bind(null, timeUnitKey)}
-        onSingleTimelineNodeSelect={onSingleTimelineNodeSelect.bind(
-          null,
-          timeUnitKey
-        )}
-        isFocus={timeUnitKey === focusUnitKey}
-        headerHeight={headerHeight}
-        measure={measure}
-        timeUnitKey={timeUnitKey}
-        isTheFirstOrLastUnit={
-          timeUnitKey === firstTimeUnitKey || timeUnitKey === lastTimeeUnitKey
-        }
-      />
+      <div style={style}>
+        <TimelineUnit
+          eventsCount={events.length}
+          bubbleSizeLevel={getBubbleLevel(timeMax, events.length)}
+          dividers={dividers}
+          bubbleLevelSizesInDivider={bubbleLevelSizesInDivider}
+          key={timeUnitKey + i}
+          onBubbleClick={onBubbleClick.bind(null, timeUnitKey)}
+          onSingleTimelineNodeSelect={onSingleTimelineNodeSelect.bind(
+            null,
+            timeUnitKey
+          )}
+          isFocus={timeUnitKey === focusUnitKey}
+          headerHeight={headerHeight}
+          measure={measure}
+          timeUnitKey={timeUnitKey}
+          isTheFirstOrLastUnit={
+            timeUnitKey === firstTimeUnitKey || timeUnitKey === lastTimeeUnitKey
+          }
+        />
+      </div>
     )
-  })
+  }
+
+  return (
+    <FixedSizeList
+      ref={listRef}
+      width={'100vw'}
+      height={listHeight}
+      itemSize={listItemHeight}
+      itemCount={timeUnitKeys.length}
+    >
+      {Row}
+    </FixedSizeList>
+  )
 }

--- a/packages/timeline/src/react-components/timeline-list.js
+++ b/packages/timeline/src/react-components/timeline-list.js
@@ -1,0 +1,46 @@
+import TimelineUnit from './timeline-unit'
+
+function getBubbleLevel(max, count) {
+  const levelSize = max / 5
+  return Math.ceil(count / levelSize) - 1
+}
+
+export default function TimelineList({
+  timeUnitKeys,
+  timeUnitEvents,
+  timeMax,
+  dividers,
+  bubbleLevelSizesInDivider,
+  onBubbleClick,
+  onSingleTimelineNodeSelect,
+  focusUnitKey,
+  headerHeight,
+  measure,
+  firstTimeUnitKey,
+  lastTimeeUnitKey,
+}) {
+  return timeUnitKeys.map((timeUnitKey, i) => {
+    const events = timeUnitEvents[timeUnitKey] || []
+    return (
+      <TimelineUnit
+        eventsCount={events.length}
+        bubbleSizeLevel={getBubbleLevel(timeMax, events.length)}
+        dividers={dividers}
+        bubbleLevelSizesInDivider={bubbleLevelSizesInDivider}
+        key={timeUnitKey + i}
+        onBubbleClick={onBubbleClick.bind(null, timeUnitKey)}
+        onSingleTimelineNodeSelect={onSingleTimelineNodeSelect.bind(
+          null,
+          timeUnitKey
+        )}
+        isFocus={timeUnitKey === focusUnitKey}
+        headerHeight={headerHeight}
+        measure={measure}
+        timeUnitKey={timeUnitKey}
+        isTheFirstOrLastUnit={
+          timeUnitKey === firstTimeUnitKey || timeUnitKey === lastTimeeUnitKey
+        }
+      />
+    )
+  })
+}

--- a/packages/timeline/src/react-components/timeline-list.js
+++ b/packages/timeline/src/react-components/timeline-list.js
@@ -1,11 +1,17 @@
 import { List } from 'react-virtualized'
 import TimelineUnit from './timeline-unit'
-import { forwardRef, useEffect, useState } from 'react'
+import { forwardRef } from 'react'
+import styled from 'styled-components'
 
 function getBubbleLevel(max, count) {
   const levelSize = max / 5
   return Math.ceil(count / levelSize) - 1
 }
+
+const RowWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`
 
 export default forwardRef(function TimelineList(
   {
@@ -21,22 +27,13 @@ export default forwardRef(function TimelineList(
     measure,
     firstTimeUnitKey,
     lastTimeUnitKey,
-    listHeight,
+    listDimemsion,
     listItemHeight,
     onTimelineListScroll,
   },
   ref
 ) {
-  const [listWidth, setListWidth] = useState(320)
-
-  useEffect(() => {
-    const windowWidth = window.innerWidth
-    if (windowWidth >= 1200) {
-      setListWidth(1200)
-    } else if (windowWidth >= 768) {
-      setListWidth(windowWidth)
-    }
-  }, [])
+  const { width, height } = listDimemsion
 
   const rowRenderer = ({ index, key, style }) => {
     const timeUnitKey = timeUnitKeys[index]
@@ -44,7 +41,7 @@ export default forwardRef(function TimelineList(
     const i = index
 
     return (
-      <div className="timeline-list-item" key={key} style={style}>
+      <RowWrapper className="timeline-list-item" key={key} style={style}>
         <TimelineUnit
           eventsCount={events.length}
           bubbleSizeLevel={getBubbleLevel(timeMax, events.length)}
@@ -64,15 +61,15 @@ export default forwardRef(function TimelineList(
             timeUnitKey === firstTimeUnitKey || timeUnitKey === lastTimeUnitKey
           }
         />
-      </div>
+      </RowWrapper>
     )
   }
 
   return (
     <List
       ref={ref}
-      width={listWidth}
-      height={listHeight}
+      width={width}
+      height={height}
       rowHeight={listItemHeight}
       rowCount={timeUnitKeys.length}
       rowRenderer={rowRenderer}

--- a/packages/timeline/src/react-components/timeline-list.js
+++ b/packages/timeline/src/react-components/timeline-list.js
@@ -1,6 +1,6 @@
 import { List } from 'react-virtualized'
 import TimelineUnit from './timeline-unit'
-import { forwardRef } from 'react'
+import { forwardRef, useEffect, useState } from 'react'
 
 function getBubbleLevel(max, count) {
   const levelSize = max / 5
@@ -27,6 +27,17 @@ export default forwardRef(function TimelineList(
   },
   ref
 ) {
+  const [listWidth, setListWidth] = useState(320)
+
+  useEffect(() => {
+    const windowWidth = window.innerWidth
+    if (windowWidth >= 1200) {
+      setListWidth(1200)
+    } else if (windowWidth >= 768) {
+      setListWidth(windowWidth)
+    }
+  }, [])
+
   const rowRenderer = ({ index, key, style }) => {
     const timeUnitKey = timeUnitKeys[index]
     const events = timeUnitEvents[timeUnitKey] || []
@@ -60,7 +71,7 @@ export default forwardRef(function TimelineList(
   return (
     <List
       ref={ref}
-      width={1200}
+      width={listWidth}
       height={listHeight}
       rowHeight={listItemHeight}
       rowCount={timeUnitKeys.length}

--- a/packages/timeline/src/react-components/timeline-list.js
+++ b/packages/timeline/src/react-components/timeline-list.js
@@ -9,7 +9,7 @@ function getBubbleLevel(max, count) {
 
 export default forwardRef(function TimelineList(
   {
-    timeUnitKeysToRender,
+    timeUnitKeys,
     timeUnitEvents,
     timeMax,
     divider,
@@ -19,22 +19,21 @@ export default forwardRef(function TimelineList(
     focusUnitKey,
     headerHeight,
     measure,
-    firstTimeUnitKeyToRender,
-    lastTimeUnitKeyToRender,
+    firstTimeUnitKey,
     lastTimeUnitKey,
-    updateFocusKey,
     listHeight,
     listItemHeight,
+    onTimelineListScroll,
   },
   ref
 ) {
   const rowRenderer = ({ index, key, style }) => {
-    const timeUnitKey = timeUnitKeysToRender[index]
+    const timeUnitKey = timeUnitKeys[index]
     const events = timeUnitEvents[timeUnitKey] || []
     const i = index
 
     return (
-      <div key={key} style={style}>
+      <div className="timeline-list-item" key={key} style={style}>
         <TimelineUnit
           eventsCount={events.length}
           bubbleSizeLevel={getBubbleLevel(timeMax, events.length)}
@@ -51,8 +50,7 @@ export default forwardRef(function TimelineList(
           measure={measure}
           timeUnitKey={timeUnitKey}
           isTheFirstOrLastUnit={
-            timeUnitKey === firstTimeUnitKeyToRender ||
-            timeUnitKey === lastTimeUnitKeyToRender
+            timeUnitKey === firstTimeUnitKey || timeUnitKey === lastTimeUnitKey
           }
         />
       </div>
@@ -61,29 +59,13 @@ export default forwardRef(function TimelineList(
 
   return (
     <List
-      id="123"
       ref={ref}
       width={1200}
       height={listHeight}
       rowHeight={listItemHeight}
-      rowCount={timeUnitKeysToRender.length}
+      rowCount={timeUnitKeys.length}
       rowRenderer={rowRenderer}
-      onScroll={() => {
-        if (ref.current) {
-          const container = ref.current.Grid._scrollingContainer // Access the actual scrolling container
-          if (container) {
-            const isAtBottom =
-              container.scrollHeight - container.scrollTop ===
-              container.clientHeight
-            if (isAtBottom) {
-              updateFocusKey(lastTimeUnitKey)
-            }
-          }
-        }
-      }}
-      onRowsRendered={({ startIndex }) => {
-        updateFocusKey(timeUnitKeysToRender[startIndex])
-      }}
+      onScroll={onTimelineListScroll}
     ></List>
   )
 })

--- a/packages/timeline/src/react-components/timeline-unit.js
+++ b/packages/timeline/src/react-components/timeline-unit.js
@@ -163,10 +163,9 @@ export default function TimelineUnit({
   measure,
   timeUnitKey,
   isTheFirstOrLastUnit,
-  dividers,
+  divider,
   bubbleLevelSizesInDivider,
 }) {
-  const divider = dividers[measure]
   const bubbleLevelSizes =
     bubbleLevelSizesInDivider[divider] || defaultBubbleLevelSizes
   const bubbleSize = bubbleLevelSizes[bubbleSizeLevel]

--- a/packages/timeline/src/react-components/timeline-unit.js
+++ b/packages/timeline/src/react-components/timeline-unit.js
@@ -9,7 +9,10 @@ const Wrapper = styled.div`
   width: 320px;
   margin: 0 auto;
   @media (min-width: 768px) {
-    width: unset;
+    width: 100%;
+  }
+  @media (min-width: 1200px) {
+    width: 1200px;
   }
 `
 const LeftPanel = styled.div`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,6 +1202,13 @@
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-transform-typescript" "^7.17.12"
 
+"@babel/runtime@^7.0.0":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
+  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
@@ -4560,6 +4567,11 @@ memfs@^3.4.3:
   dependencies:
     fs-monkey "1.0.3"
 
+"memoize-one@>=3.1.1 <6":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
@@ -5400,6 +5412,14 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-window@^1.8.9:
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.9.tgz#24bc346be73d0468cdf91998aac94e32bc7fa6a8"
+  integrity sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
+
 react@18.1.0:
   version "18.1.0"
   resolved "https://registry.npmjs.org/react/-/react-18.1.0.tgz"
@@ -5504,6 +5524,11 @@ regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
   version "0.13.9"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regenerator-transform@^0.15.0:
   version "0.15.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,19 +1202,19 @@
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-transform-typescript" "^7.17.12"
 
-"@babel/runtime@^7.0.0":
-  version "7.22.10"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
-  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
 "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
   dependencies:
     regenerator-runtime "^0.13.11"
+
+"@babel/runtime@^7.7.2":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
+  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
 
 "@babel/runtime@^7.8.4":
   version "7.17.9"
@@ -2527,6 +2527,11 @@ clone@^1.0.2:
   resolved "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
+clsx@^1.0.4:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 co@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
@@ -2891,7 +2896,7 @@ dom-converter@^0.2.0:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^5.0.1:
+dom-helpers@^5.0.1, dom-helpers@^5.1.3:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
   integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
@@ -4567,11 +4572,6 @@ memfs@^3.4.3:
   dependencies:
     fs-monkey "1.0.3"
 
-"memoize-one@>=3.1.1 <6":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
-
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
@@ -5328,7 +5328,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -5402,6 +5402,11 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
@@ -5412,13 +5417,17 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-window@^1.8.9:
-  version "1.8.9"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.9.tgz#24bc346be73d0468cdf91998aac94e32bc7fa6a8"
-  integrity sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==
+react-virtualized@^9.22.4:
+  version "9.22.5"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.5.tgz#bfb96fed519de378b50d8c0064b92994b3b91620"
+  integrity sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==
   dependencies:
-    "@babel/runtime" "^7.0.0"
-    memoize-one ">=3.1.1 <6"
+    "@babel/runtime" "^7.7.2"
+    clsx "^1.0.4"
+    dom-helpers "^5.1.3"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-lifecycles-compat "^3.0.4"
 
 react@18.1.0:
   version "18.1.0"


### PR DESCRIPTION
# Notable change

原本時間軸的作法是直接把所有的時間點 render 出來，在日層級會造成一次有 2000 個以上的 component 同時 render/re-render 造成 iOS mobile 網頁崩潰的狀況，經過 survey 後改採用 react-virtualized 的套件，將 render 的範圍侷限在時間軸畫面中可見範圍，避免一次將大量個 component 同時 render 出來。

### 優點：
- 效能優化：不再需要一次把所有時間點 render 出來，僅針對在畫面中的等分數量的節點去 render (5等分就是5個節點)
### 缺點：
- 不能把整個時間軸全部展開，只能在一個特定範圍內 (通常是 100vh )滑動
- 因為是在 scroll container (100vh) 中滑動，頁面在滑動的時候需要做特殊處理才能確保 100vh 都有被滑完才繼續滑到頁面其他部分

### Todo

- 嘗試在 Timeline 滑到頁面上方的時候 block 整個頁面的 scroll，等到 Timeline 滑到底的時候再解除讓使用者可以繼續往下滑，避免錯過重要資訊，反方向亦然。
