### PR TITLE
chore(image): support ECMAScript modules (ES modules)

### DIFF
--- a/packages/image/.babelrc.js
+++ b/packages/image/.babelrc.js
@@ -1,0 +1,15 @@
+const buildTarget = process.env.BUILD_TARGET || 'esmodule' // another value could be 'commonjs'
+
+export default {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        modules: buildTarget === 'esmodule' ? false : 'commonjs',
+        targets: {
+          node: '14',
+        },
+      },
+    ],
+  ],
+}

--- a/packages/image/CHANGELOG.md
+++ b/packages/image/CHANGELOG.md
@@ -1,6 +1,23 @@
 # @readr-media/react-image Changelog
 
 
+## 2023-08-30, Version 2.0.0
+
+### Notable Changes
+- Support ES Modules
+
+
+### Commits
+* \[[`6a75564022`](https://github.com/readr-media/react-image/commit/6a75564022)] - chore(image): update Makefile, tsconfig, package.json to support ESM (DianYangFu)
+* \[[`069ab5d720`](https://github.com/readr-media/react-image/commit/069ab5d720)] - chore(image): update webpack.config.js to fit module type (DianYangFu)
+* \[[`aac8f3fe8a`](https://github.com/readr-media/react-image/commit/aac8f3fe8a)] - chore(image): add devDep `@babel/plugin-transform-runtime` (DianYangFu)
+* \[[`98a0ef9866`](https://github.com/readr-media/react-image/commit/98a0ef9866)] - chore(image): update file import path to support module type (DianYangFu)
+* \[[`8ece49249f`](https://github.com/readr-media/react-image/commit/8ece49249f)] - chore(image): add `.babelrc.js` (DianYangFu)
+* \[[`faf3363155`](https://github.com/readr-media/react-image/commit/faf3363155)] - refactor(image): add folder types to place `@typedef`, export type (DianYangFu)
+* \[[`057f317136`](https://github.com/readr-media/react-image/commit/057f317136)] - doc(image): update README.md (DianYangFu)
+* \[[`6eb802ad88`](https://github.com/readr-media/react-image/commit/6eb802ad88)] - chore(image): bump version into `2.0.0` (DianYangFu)
+
+
 ## 2023-05-14, Version 1.6.0
 
 ### Notable Changes

--- a/packages/image/Makefile
+++ b/packages/image/Makefile
@@ -2,7 +2,7 @@ P := "\\033[32m[+]\\033[0m"
 
 help:
 	@echo "$(P) make dev - Start webpack dev server and watch any changes"
-	@echo "$(P) make build - Transpile jsx, es6 and above to es5 files, create type declaration files, and build pacakge bundle"
+	@echo "$(P) make build - Transpile jsx, typescript to js, and build webpack bundles"
 
 dev: 
 	@echo "$(P) Start webpack dev server"
@@ -10,10 +10,14 @@ dev:
 
 build-lib:
 	@echo "$(P) Transpile es6, jsx and (typescript) to es5"
-	NODE_ENV=production yarn babel src --out-dir lib --copy-files --root-mode upward
-	@echo "$(P) Create type declaration file"
+	mkdir -p lib
+	BUILD_TARGET=esmodule NODE_ENV=production yarn babel src --out-dir lib/esm --copy-files --root-mode upward
+	echo '{ "type": "module" }' > lib/esm/package.json
+	BUILD_TARGET=commonjs NODE_ENV=production yarn babel src --out-dir lib/cjs --copy-files --root-mode upward
+	echo '{ "type": "commonjs" }' > lib/cjs/package.json
 	yarn run build-type
 
+	
 build: clean build-lib
 
 clean:

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -85,31 +85,45 @@ $ npm run dev
 $ make dev
 ```
 
-## Build (Webpack Bundles and ES5 Transpiling)
+## Build
+Transpile React, ES6 Codes to ES5, and generate two module system (ES module and Commonjs) at the same time
+
 ```
 $ npm run build
 // or
 $ make build
-```
-
-### Build Webpack Bundles 
-```
-$ make build-dist
-```
-
-### Transpile React, ES6 Codes to ES5 
-```
+// or
 $ make build-lib
 ```
 
+
 ### NPM Publish
-After executing `Build` scripts, we will have `./dist` and `/lib` folders,
+After executing `Build` scripts, we will have `/lib` folders,
 and then we can execute publish command,
 ```
 npm publish
 ```
 
 Note: before publish npm package, we need to bump the package version first. 
+
+### Folder Structure of Build File
+```
+@readr-media/react-image
+  |  
+  ├──lib
+  |    └── cjs    // for CommonJS project
+  |    └── esm    // for ES Modules project
+  |    └── types  // for Typescript 
+  |    
+  ├── README.md
+  ├── CHANGELOG.md
+  └── package.json
+```
+
+Note: 
+- If your Node.js project has enable ES Modules, it will use file in `/esm` folder when import this package.
+- If not, it will use file in `/cjs` folder when import this package.
+- See [Node.js Documentation](https://nodejs.org/api/esm.html#modules-ecmascript-modules) to get more info about ES Modules.
 
 
 ## TODOs

--- a/packages/image/dev/entry.js
+++ b/packages/image/dev/entry.js
@@ -1,4 +1,4 @@
-import Image from '../src/react-components'
+import Image from '../src/react-components/index.js'
 import React from 'react' // eslint-disable-line
 import { createRoot } from 'react-dom/client'
 

--- a/packages/image/dev/webpack.config.js
+++ b/packages/image/dev/webpack.config.js
@@ -1,10 +1,16 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin')
-const path = require('path')
+import * as url from 'url'
 
-module.exports = {
+import HtmlWebpackPlugin from 'html-webpack-plugin'
+import path from 'path'
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+
+export default {
   mode: 'development',
   entry: {
     main: path.resolve(__dirname, './entry.js'),
+  },
+  output: {
+    path: path.resolve(__dirname, './dist'),
   },
   devServer: {
     hot: false,
@@ -22,7 +28,15 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['@babel/preset-env', '@babel/preset-react'],
+            presets: [
+              [
+                '@babel/preset-env',
+                {
+                  modules: false,
+                },
+              ],
+              '@babel/preset-react',
+            ],
           },
         },
       },

--- a/packages/image/dev/webpack.config.js
+++ b/packages/image/dev/webpack.config.js
@@ -37,6 +37,7 @@ export default {
               ],
               '@babel/preset-react',
             ],
+            plugins: ['@babel/plugin-transform-runtime'],
           },
         },
       },

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -38,6 +38,7 @@
     "CHANGELOG.md"
   ],
   "devDependencies": {
+    "@babel/plugin-transform-runtime": "^7.22.10",
     "@types/node": "^18.15.3",
     "typescript": "^4.9.5"
   }

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -2,8 +2,14 @@
   "name": "@readr-media/react-image",
   "version": "1.6.0",
   "description": "",
-  "main": "lib/index.js",
-  "types": "dist/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/types/index.d.ts",
+  "exports": {
+    "import": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "make dev",
@@ -24,12 +30,11 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": "18.1.0",
-    "react-dom": "^18.1.0"
+    "react": "18.2.0",
+    "react-dom": "^18.2.0"
   },
   "files": [
     "lib",
-    "dist",
     "CHANGELOG.md"
   ],
   "devDependencies": {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-image",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "description": "",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/image/src/index.js
+++ b/packages/image/src/index.js
@@ -1,3 +1,5 @@
 import Image from './react-components/index.js'
 
+export * from './types/index.js'
+
 export default Image

--- a/packages/image/src/index.js
+++ b/packages/image/src/index.js
@@ -1,3 +1,3 @@
-import Image from './react-components'
+import Image from './react-components/index.js'
 
 export default Image

--- a/packages/image/src/react-components/index.js
+++ b/packages/image/src/react-components/index.js
@@ -1,70 +1,12 @@
 import React, { useEffect, useRef } from 'react' // eslint-disable-line
 
 /**
- * @typedef {Object} Rwd
- * @property {string} [mobile]
- * @property {string} [tablet]
- * @property {string} [laptop]
- * @property {string} [desktop]
- * @property {string} [default]
- */
-/**
- * @typedef {Object} Breakpoint
- * @property {string} [mobile]
- * @property {string} [tablet]
- * @property {string} [laptop]
- * @property {string} [desktop]
- */
-
-/**
  * Check an String contain integer, for example, 'w1200' is valid, 'original' or 'randomName' is not valid
  */
 const REGEX = /(\d+)/
 
 /**
- *
- * @param {Object} props
- * @param {Object} props.images
- * - list of URL of images want to loaded.
- * - required.
- * @param {String} [props.loadingImage]
- * - placeholder when loading image, it will show when item of `images` is not loaded.
- * - optional, default value is `""`.
- * @param {String} [props.defaultImage]
- * - default image, it will show if all items of `images` can not be loaded, and would become loading animation if `loadingImage` is not passed in.
- * - optional, default value is `""`.
- * @param {String} [props.alt]
- * - image alt.
- * - optional, default value is `""`.
- * @param {"fill"|"contain"|"cover"|"scale-down"|"none"|"initial"|"inherit"} [props.objectFit] - image CSS property. Optional, default value is `"cover"`.
- * @param {String | Number} [props.width]
- * - image width.
- * - optional, default value is `"100%"`.
- * @param {String | Number} [props.height]
- * - image height.
- * - optional, default value is `"100%"`.
- * @param {boolean} [props.priority]
- * - should preload image
- * @param {Boolean} [props.debugMode]
- * - can set if is in debug mode
- * - if `true`, then will print log after image loaded successfully of occur error.
- * - optional, default value is `false`.
- * @param {Breakpoint} [props.breakpoint]
- * - breakpoint of viewport width.
- * - optional, default value is `{ mobile: '767px', tablet: '1199px', laptop: '1439px', desktop: '2439px'}`
- * - For example, if we set breakpoint as `{ mobile: '767px', tablet: '1199px', laptop: '1439px', desktop: '2439px'}`,
- * - which means if viewport width is not greater then 767px, screen is mobile size, then we will get image sizes by comparing the value of `props.rwd`.
- * - It will affect which url of 'props.images' should loaded first.
- * @param {Rwd} [props.rwd]
- * - can set different sizes of image want to load first on different breakpoint of vw (viewport width),
- * such as {mobile: '300px', tablet: '400px', laptop: '800px', desktop: '1200px', default: '1600px'}.
- * - optional, default value is `{ mobile: '100vw', tablet: '100vw', laptop: '100vw', desktop: '100vw', default: '100vw'}`
- * - using `props.breakpoint` and `props.rwd`, you can decide different sizes of image is on each vw.
- * - if this param is default value, this sizes of images will equal to vw.
- * @param {IntersectionObserverInit} [props.intersectionObserverOptions]
- * - Options of intersection observers, let you control the circumstance of observers.
- * - Optional, default value is `{ root: null, rootMargin: '0px', threshold: 0.25, }`.
- * - See [Mdn Docs](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to get more information.
+ * @param {import('../types/index').ImageProps} props
  * @returns {JSX.Element}
  */
 export default function CustomImage({

--- a/packages/image/src/types/index.js
+++ b/packages/image/src/types/index.js
@@ -1,0 +1,62 @@
+/**
+ * @typedef {Object} Rwd
+ * @property {string} [mobile]
+ * @property {string} [tablet]
+ * @property {string} [laptop]
+ * @property {string} [desktop]
+ * @property {string} [default]
+ */
+/**
+ * @typedef {Object} Breakpoint
+ * @property {string} [mobile]
+ * @property {string} [tablet]
+ * @property {string} [laptop]
+ * @property {string} [desktop]
+ */
+
+/**
+ * @typedef {Object} ImageProps
+ * @property {Object} props.images
+ * - list of URL of images want to loaded.
+ * - required.
+ * @property {String} [props.loadingImage]
+ * - placeholder when loading image, it will show when item of `images` is not loaded.
+ * - optional, default value is `""`.
+ * @property {String} [props.defaultImage]
+ * - default image, it will show if all items of `images` can not be loaded, and would become loading animation if `loadingImage` is not passed in.
+ * - optional, default value is `""`.
+ * @property {String} [props.alt]
+ * - image alt.
+ * - optional, default value is `""`.
+ * @property {"fill"|"contain"|"cover"|"scale-down"|"none"|"initial"|"inherit"} [props.objectFit] - image CSS property. Optional, default value is `"cover"`.
+ * @property {String | Number} [props.width]
+ * - image width.
+ * - optional, default value is `"100%"`.
+ * @property {String | Number} [props.height]
+ * - image height.
+ * - optional, default value is `"100%"`.
+ * @property {boolean} [props.priority]
+ * - should preload image
+ * @property {Boolean} [props.debugMode]
+ * - can set if is in debug mode
+ * - if `true`, then will print log after image loaded successfully of occur error.
+ * - optional, default value is `false`.
+ * @property {Breakpoint} [props.breakpoint]
+ * - breakpoint of viewport width.
+ * - optional, default value is `{ mobile: '767px', tablet: '1199px', laptop: '1439px', desktop: '2439px'}`
+ * - For example, if we set breakpoint as `{ mobile: '767px', tablet: '1199px', laptop: '1439px', desktop: '2439px'}`,
+ * - which means if viewport width is not greater then 767px, screen is mobile size, then we will get image sizes by comparing the value of `props.rwd`.
+ * - It will affect which url of 'props.images' should loaded first.
+ * @property {Rwd} [props.rwd]
+ * - can set different sizes of image want to load first on different breakpoint of vw (viewport width),
+ * such as {mobile: '300px', tablet: '400px', laptop: '800px', desktop: '1200px', default: '1600px'}.
+ * - optional, default value is `{ mobile: '100vw', tablet: '100vw', laptop: '100vw', desktop: '100vw', default: '100vw'}`
+ * - using `props.breakpoint` and `props.rwd`, you can decide different sizes of image is on each vw.
+ * - if this param is default value, this sizes of images will equal to vw.
+ * @property {IntersectionObserverInit} [props.intersectionObserverOptions]
+ * - Options of intersection observers, let you control the circumstance of observers.
+ * - Optional, default value is `{ root: null, rootMargin: '0px', threshold: 0.25, }`.
+ * - See [Mdn Docs](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to get more information.
+ */
+
+export default {}

--- a/packages/image/tsconfig.json
+++ b/packages/image/tsconfig.json
@@ -14,7 +14,7 @@
     // Types should go into this directory.
     // Removing this would place the .d.ts files
     // next to the .js files
-    "outDir": "dist",
+    "outDir": "lib/types",
     // go to js file when using IDE functions like
     // "Go to Definition" in VSCode
     "declarationMap": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,11 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz"
   integrity sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==
 
+"@babel/compat-data@^7.22.6", "@babel/compat-data@^7.22.9":
+  version "7.22.9"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.9.tgz#71cdb00a1ce3a329ce4cbec3a44f9fef35669730"
+  integrity sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==
+
 "@babel/core@^7.11.1":
   version "7.17.12"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.17.12.tgz"
@@ -139,6 +144,17 @@
     browserslist "^4.20.2"
     semver "^6.3.0"
 
+"@babel/helper-compilation-targets@^7.22.6":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz#01d648bbc25dd88f513d862ee0df27b7d4e67024"
+  integrity sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==
+  dependencies:
+    "@babel/compat-data" "^7.22.9"
+    "@babel/helper-validator-option" "^7.22.5"
+    browserslist "^4.21.9"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
 "@babel/helper-create-class-features-plugin@^7.17.12":
   version "7.17.12"
   resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.12.tgz"
@@ -187,6 +203,17 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
+"@babel/helper-define-polyfill-provider@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.2.tgz#82c825cadeeeee7aad237618ebbe8fa1710015d7"
+  integrity sha512-k0qnnOqHn5dK9pZpfD5XXZ9SojAITdCKRn2Lp6rnDGzIbaP0rHyMPk/4wsSxVBVz4RfN0q6VpXWP2pDGIoQ7hw==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.22.6"
+    "@babel/helper-plugin-utils" "^7.22.5"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
+
 "@babel/helper-environment-visitor@^7.16.7":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz"
@@ -230,6 +257,13 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
+"@babel/helper-module-imports@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz#1a8f4c9f4027d23f520bd76b364d44434a72660c"
+  integrity sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-module-transforms@^7.17.12":
   version "7.17.12"
   resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.12.tgz"
@@ -269,6 +303,11 @@
   version "7.17.12"
   resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz"
   integrity sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==
+
+"@babel/helper-plugin-utils@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
+  integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
 
 "@babel/helper-remap-async-to-generator@^7.16.8":
   version "7.16.8"
@@ -311,15 +350,30 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
+"@babel/helper-string-parser@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
+  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
+
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
+"@babel/helper-validator-identifier@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
+  integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
+
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz"
   integrity sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
+
+"@babel/helper-validator-option@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz#de52000a15a177413c8234fa3a8af4ee8102d0ac"
+  integrity sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==
 
 "@babel/helper-wrap-function@^7.16.8":
   version "7.16.8"
@@ -949,6 +1003,18 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.17.12"
 
+"@babel/plugin-transform-runtime@^7.22.10":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.10.tgz#89eda6daf1d3af6f36fb368766553054c8d7cd46"
+  integrity sha512-RchI7HePu1eu0CYNKHHHQdfenZcM4nz8rew5B1VWqeRKdcwW5aQ5HeG9eTUbWiAS1UrmHVLmoxTWHt3iLD/NhA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.22.5"
+    "@babel/helper-plugin-utils" "^7.22.5"
+    babel-plugin-polyfill-corejs2 "^0.4.5"
+    babel-plugin-polyfill-corejs3 "^0.8.3"
+    babel-plugin-polyfill-regenerator "^0.5.2"
+    semver "^6.3.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.16.7":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz"
@@ -1278,6 +1344,15 @@
   integrity sha512-rH8i29wcZ6x9xjzI5ILHL/yZkbQnCERdHlogKuIb4PUr7do4iT8DPekrTbBLWTnRQm6U0GYABbTMSzijmEqlAg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.22.5":
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.11.tgz#0e65a6a1d4d9cbaa892b2213f6159485fe632ea2"
+  integrity sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
 "@discoveryjs/json-ext@^0.5.0":
@@ -2189,6 +2264,15 @@ babel-plugin-polyfill-corejs2@^0.3.0:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
     semver "^6.1.1"
 
+babel-plugin-polyfill-corejs2@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.5.tgz#8097b4cb4af5b64a1d11332b6fb72ef5e64a054c"
+  integrity sha512-19hwUH5FKl49JEsvyTcoHakh6BE0wgXLLptIyKZ3PijHc/Ci521wygORCUCCred+E/twuqRyAkE02BAWPmsHOg==
+  dependencies:
+    "@babel/compat-data" "^7.22.6"
+    "@babel/helper-define-polyfill-provider" "^0.4.2"
+    semver "^6.3.1"
+
 babel-plugin-polyfill-corejs3@^0.5.0:
   version "0.5.2"
   resolved "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz"
@@ -2197,12 +2281,27 @@ babel-plugin-polyfill-corejs3@^0.5.0:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
     core-js-compat "^3.21.0"
 
+babel-plugin-polyfill-corejs3@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.3.tgz#b4f719d0ad9bb8e0c23e3e630c0c8ec6dd7a1c52"
+  integrity sha512-z41XaniZL26WLrvjy7soabMXrfPWARN25PZoriDEiLMxAp50AUW3t35BGQUMg5xK3UrpVTtagIDklxYa+MhiNA==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.4.2"
+    core-js-compat "^3.31.0"
+
 babel-plugin-polyfill-regenerator@^0.3.0:
   version "0.3.1"
   resolved "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz"
   integrity sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
+
+babel-plugin-polyfill-regenerator@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.2.tgz#80d0f3e1098c080c8b5a65f41e9427af692dc326"
+  integrity sha512-tAlOptU0Xj34V1Y2PNTL4Y0FOJMDB6bZmoW39FeCQIhigGLkqu3Fj6uiXpxIf6Ij274ENdYx64y6Au+ZKlb1IA==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.4.2"
 
 "babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^2.0.7:
   version "2.0.7"
@@ -2327,6 +2426,16 @@ browserslist@^4.14.5, browserslist@^4.20.2, browserslist@^4.20.3:
     node-releases "^2.0.3"
     picocolors "^1.0.0"
 
+browserslist@^4.21.10, browserslist@^4.21.9:
+  version "4.21.10"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.10.tgz#dbbac576628c13d3b2231332cb2ec5a46e015bb0"
+  integrity sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==
+  dependencies:
+    caniuse-lite "^1.0.30001517"
+    electron-to-chromium "^1.4.477"
+    node-releases "^2.0.13"
+    update-browserslist-db "^1.0.11"
+
 buffer-from@^0.1.1:
   version "0.1.2"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz"
@@ -2390,6 +2499,11 @@ caniuse-lite@^1.0.30001332:
   version "1.0.30001341"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz"
   integrity sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
+
+caniuse-lite@^1.0.30001517:
+  version "1.0.30001524"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz#1e14bce4f43c41a7deaeb5ebfe86664fe8dadb80"
+  integrity sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -2672,6 +2786,13 @@ core-js-compat@^3.21.0, core-js-compat@^3.22.1:
   dependencies:
     browserslist "^4.20.3"
     semver "7.0.0"
+
+core-js-compat@^3.31.0:
+  version "3.32.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.32.1.tgz#55f9a7d297c0761a8eb1d31b593e0f5b6ffae964"
+  integrity sha512-GSvKDv4wE0bPnQtjklV101juQ85g6H3rm5PDP20mqlS5j0kXF3pP97YvAu5hl+uFHqMictp3b2VxOHljWMAtuA==
+  dependencies:
+    browserslist "^4.21.10"
 
 core-js@^3.6.4:
   version "3.22.5"
@@ -2977,6 +3098,11 @@ electron-to-chromium@^1.4.118:
   version "1.4.137"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
+
+electron-to-chromium@^1.4.477:
+  version "1.4.503"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.503.tgz#7bd43927ea9b4198697672d28d8fbd0da016a7a1"
+  integrity sha512-LF2IQit4B0VrUHFeQkWhZm97KuJSGF2WJqq1InpY+ECpFRkXd8yTIaTtJxsO0OKDmiBYwWqcrNaXOurn2T2wiA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -4382,6 +4508,13 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz"
@@ -4981,6 +5114,11 @@ node-forge@^1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
+node-releases@^2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d"
+  integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
 
 node-releases@^2.0.3:
   version "2.0.4"
@@ -6364,6 +6502,11 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
 semver@^7.2.1:
   version "7.3.7"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz"
@@ -7098,6 +7241,14 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
+update-browserslist-db@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz#9a2a641ad2907ae7b3616506f4b977851db5b940"
+  integrity sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
@@ -7450,6 +7601,11 @@ ws@^8.4.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Notable Change
調整多個檔案內容，使其可以輸出es module

## Commit Details
- [3278971](https://github.com/readr-media/react/pull/235/commits/32789718d3396f9812ba6d5652286e7b8479a807): 調整Makefile, tsconfig, package.json，使其可以輸出esm。
  - Makefile與 package.json 是參考dropping-text的相對應檔案，tsconfg則是參考[這篇](https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html)的作法，使得esm與cjs皆有對應的d.ts檔案。

- [4bf9131](https://github.com/readr-media/react/pull/235/commits/4bf91311b9f11431873292ec86141e8db2052a91)：新增devDep `@babel/plugin-transform-runtime`，該devDep是用於避免dev mode 時無法使用async/await。
- [b69faff](https://github.com/readr-media/react/pull/235/commits/b69faffcd420949c845deda738d3820714d499d7)：調整webpack.config.js，使其使用esm，並加入了plugins `@babel/plugin-transform-runtime`。
- [647268c](https://github.com/readr-media/react/pull/235/commits/647268c27d8ac1ce190642c79e76a01968296349)：調整import file path，使其在package.json中指定 `type` 為 `module` 時，仍可以正確import。see [Docs](https://webpack.js.org/configuration/module/#resolvefullyspecified)
- [df3966d](https://github.com/readr-media/react/pull/235/commits/df3966dbd82b14269e1300cf6ae92f794acd2cdc)：新增`.babelrc.js`，使其可以正確輸出cjs與esm兩種類型的package。

## TODO:
1. update change log
