### PR TITLE
feat(image): support webp format, rewrite Promise to improve readability

### DIFF
--- a/packages/image/CHANGELOG.md
+++ b/packages/image/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @readr-media/react-image Changelog
 
+## 2023-08-31, Version 2.1.0
+
+### Notable Changes
+- Improve code readability, use `async/await` to replace Promise `.then/.catch`. 
+- Support sequential loading `.webp` images.
+
+
+### Commits
+* \[[`13c393601f`](https://github.com/readr-media/react-image/commit/13c393601f)] - refactor(image): replace Promise `.then/.catch` to `async/await` (DianYangFu)
+* \[[`81ca44c521`](https://github.com/readr-media/react-image/commit/81ca44c521)] - feat(image): support webp format (DianYangFu)
+* \[[`3a8c4e810c`](https://github.com/readr-media/react-image/commit/3a8c4e810c)] - doc(image): update README.md (DianYangFu)
+* \[[`0b41d9e91b`](https://github.com/readr-media/react-image/commit/0b41d9e91b)] - chore(image): bump version to `2.1.0` (DianYangFu)
+
+
 
 ## 2023-08-30, Version 2.0.0
 

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -50,7 +50,8 @@ export default function SomeComponent() {
 
 | 名稱         | 資料型別 | 必須 | 預設值           | 說明                                                                                                                                                                                                                                                    |
 | ------------ | -------- | ---- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| images       | Object   | `V`  | `{original: ""}` | 圖片設定，範例： `{ w400: '400.png',w800 : '800.png', w1200: '1200.png', original: 'original.png' }`。會由`w400`、`w800`、`w1200`、`original`依序載入                                                                                                   |
+| images       | Object   | `V`  | `{original: ""}` | 圖片設定，範例： `{ w400: '400.png', w800: '800.png', w1200: '1200.png', original: 'original.png' }`。圖片載入順序詳見 [Sequence of Loading Images](##sequence-of-loading-images)。|
+| imagesWebP       | Object   |   | `null` | 圖片設定，範例： `{ w400: '400.webp', w800: '800.webp', w1200: '1200.webp', original: 'original.webp' }`。圖片載入順序詳見 [Sequence of Loading Images](##sequence-of-loading-images)。|
 | defaultImage | String   |      | `""`             | 預設圖片。當`image`皆載入失敗時，則載入預設圖片。<br>當`loadingImage`未傳入時，則以預設圖片作為圖片載入動畫效果。                                                                                                                                       |
 | loadingImage | String   |      | `""`             | 載入動畫效果，作為載入圖片的動畫。目前僅接受圖片檔URL。                                                                                                                                                                                                 |
 | alt          | String   |      | `""`             | 替代文字                                                                                                                                                                                                                                                |
@@ -64,8 +65,34 @@ export default function SomeComponent() {
 |intersectionObserverOptions|Object  |      |`{root: null, rootMargin: '0px', threshold: 0.25, }` |intersection observer的選項，用於調整圖片懶載入的條件。僅在參數`priority`為`false`的情況才會生效 |
 
 
+## Sequence of Loading Images
 
+- 當只有傳入 `images` 時，會依據解析度由小至大載入。
+- 如果同時有傳入 `images` 與 `imagesWebP` 時，會依據解析度由小至大載入，若解析度相同，則webP圖片優先載入。
 
+舉例來說，若僅有傳入 `images`，且傳入的 `images` 為：
+```
+{
+      original: 'original.png',
+      w480: 'w480.png',
+      w800: 'w800.png',
+      w1600: 'w1600.png',
+      w2400: 'w2400.png',
+}
+```
+圖片載入順序為 `w480.png` -> `w800.png` -> `w1600.png` -> `w2400.png` -> `original.png`。
+
+如果除了傳入上述 `images` ，亦有傳入 `imagesWebP`，且傳入的 `imagesWebP` 為：
+```
+{
+      original: 'original.webp',
+      w480: 'w480.webp',
+      w800: 'w800.webp',
+      w1600: 'w1600.webp',
+      w2400: 'w2400.webp',
+},
+```
+圖片載入順序為 `w480.webp` -> `w480.png` -> `w800.webp` -> `w800.png` -> `w1600.webp` ->`w1600.png` -> `w2400.webp` -> `w2400.png` -> `original.webp` -> `original.png`。
 
 ## Precautions
 若使用該套件時，禁用了瀏覽器的cache，則同張圖片會載入至少兩次（一次在函式`loadImage()`中載入各個大小的圖片，一次則在useEffect中，將成功載入的圖片掛載至`<img>`上），這是正常的現象。

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-image",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/image/src/types/index.js
+++ b/packages/image/src/types/index.js
@@ -19,6 +19,9 @@
  * @property {Object} props.images
  * - list of URL of images want to loaded.
  * - required.
+ * @property {Object | null} [props.imagesWebP]
+ * - list of URL of webP images want to loaded.
+ * - optional, default value in null.
  * @property {String} [props.loadingImage]
  * - placeholder when loading image, it will show when item of `images` is not loaded.
  * - optional, default value is `""`.


### PR DESCRIPTION
## Notable Change
1. 將Promise .then/.catch 改為async/await，提升程式碼閱讀性。
2. 新增props `imagesWebP`，可傳入多組圖片url。詳細載入順序詳見README.md。