### PR TITLE
feat(theatre): change font element to dangerouslySetInnerHTML

### DIFF
--- a/packages/dropping-text/package.json
+++ b/packages/dropping-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-dropping-text",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "description": "",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/dropping-text/src/react-components/index.js
+++ b/packages/dropping-text/src/react-components/index.js
@@ -60,6 +60,7 @@ const Block = styled.div`
 `
 
 const Text = styled.span`
+  color: #000000;
   font-size: 20px;
   user-select: none;
   visibility: hidden;
@@ -293,6 +294,7 @@ export default function DroppingText({
       {truncatedTextArr.map((txt, idx) => {
         return (
           <Text
+            className="text"
             key={idx}
             data-dropping-text
             dangerouslySetInnerHTML={{ __html: txt }}

--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-embed-code-generator",
-  "version": "2.4.3-alpha.2",
+  "version": "2.4.3-alpha.4",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@readr-media/react-dropping-text": "1.0.7",
+    "@readr-media/react-dropping-text": "1.0.9",
     "@readr-media/react-dual-slides": "^1.1.0",
     "@readr-media/react-election-widgets": "1.0.2",
     "@readr-media/react-feedback": "^3.0.2",
@@ -38,7 +38,7 @@
     "@readr-media/react-qa-list": "2.0.1",
     "@readr-media/react-questionnaire": "2.0.0",
     "@readr-media/react-random-text-selector": "^1.0.2",
-    "@readr-media/react-theatre": "^1.1.0",
+    "@readr-media/react-theatre": "^1.3.0",
     "@readr-media/react-three-story-points": "1.0.2",
     "@readr-media/react-timeline": "1.1.0-alpha.1",
     "lodash": "^4.17.21",
@@ -50,7 +50,7 @@
     "@babel/eslint-parser": "^7.11.4",
     "@babel/preset-env": "^7.17.12",
     "@babel/preset-react": "^7.17.12",
-    "@readr-media/react-embed-code-generator": "2.4.3-alpha.2",
+    "@readr-media/react-embed-code-generator": "2.4.3-alpha.4",
     "@svgr/webpack": "^6.2.1",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.5",

--- a/packages/embed-code-generator/yarn.lock
+++ b/packages/embed-code-generator/yarn.lock
@@ -1160,18 +1160,10 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
-"@readr-media/react-dropping-text@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-dropping-text/-/react-dropping-text-1.0.6.tgz#b66c2dde91fd95af93da7bc0c1191b4f704635ed"
-  integrity sha512-0lA5gzi+DBU6fXZOC+Rd3mU0rYVgLha9eIUlKGIJwYmx3ucwT1BkT7l3E/lUgQB0Im4C6bOEXlrrKkWmwTiIAw==
-  dependencies:
-    matter-js "^0.19.0"
-    react-intersection-observer "^9.3.5"
-
-"@readr-media/react-dropping-text@1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-dropping-text/-/react-dropping-text-1.0.7.tgz#f30897154e721386d35fe69c6f1d1cd4ba38723e"
-  integrity sha512-49YgIgPrqmI/4wo1d+qBqLs+V7yo0oYbXBMYpfhEMUdJb2/E0eBfPp5mlNMGmmdKnodtfI+V7t8bZF5iFS/qXg==
+"@readr-media/react-dropping-text@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-dropping-text/-/react-dropping-text-1.0.9.tgz#b0aac6129674ffac0b30d35505fc2f65a60c41ef"
+  integrity sha512-VM+dCxa/bQbGPLxIqpE1XmkNYsumqWwf7XGfHZaoWlPz/jjkJnBapuve7cYNMrdAA+4IHQw0CCAlkbwSqeHR0g==
   dependencies:
     matter-js "^0.19.0"
     react-intersection-observer "^9.3.5"
@@ -1192,12 +1184,12 @@
     "@twreporter/errors" "^1.1.1"
     axios "^0.27.2"
 
-"@readr-media/react-embed-code-generator@2.4.3-alpha.2":
-  version "2.4.3-alpha.1"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-embed-code-generator/-/react-embed-code-generator-2.4.3-alpha.1.tgz#092054926b2b1f9469b4570fdbd11c15823223a0"
-  integrity sha512-a9gTRzXDI1PNEhcyjeQUHXzFABIGF3WTbVxShXjaGwg9p3nLEZ8s9a6j7eO7bNFU0wPIn0GoeY11Ilbj8GVEzQ==
+"@readr-media/react-embed-code-generator@2.4.3-alpha.4":
+  version "2.4.3-alpha.4"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-embed-code-generator/-/react-embed-code-generator-2.4.3-alpha.4.tgz#88de7f8daefc2128511b89ac80ea1f18716f95f2"
+  integrity sha512-n9lifay9Oc984s8/sgNo78+BPbU/N2qH19b5YzQwDq57t7r/8ZdeSBj8fZ5ZSgKREXBQug2MNBFZg7dGuXp9Jg==
   dependencies:
-    "@readr-media/react-dropping-text" "1.0.6"
+    "@readr-media/react-dropping-text" "1.0.9"
     "@readr-media/react-dual-slides" "^1.1.0"
     "@readr-media/react-election-widgets" "1.0.2"
     "@readr-media/react-feedback" "^3.0.2"
@@ -1207,7 +1199,7 @@
     "@readr-media/react-qa-list" "2.0.1"
     "@readr-media/react-questionnaire" "2.0.0"
     "@readr-media/react-random-text-selector" "^1.0.2"
-    "@readr-media/react-theatre" "^1.1.0"
+    "@readr-media/react-theatre" "^1.3.0"
     "@readr-media/react-three-story-points" "1.0.2"
     "@readr-media/react-timeline" "1.1.0-alpha.1"
     lodash "^4.17.21"
@@ -1290,10 +1282,10 @@
   dependencies:
     axios "^1.3.5"
 
-"@readr-media/react-theatre@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-theatre/-/react-theatre-1.1.0.tgz#18a8e099f8d22439585403709f67ab5c0301fcbd"
-  integrity sha512-PnFJr81c5h1/TD0C3PjkHCxfXMAQ3xSTqf90HE478pDxjQbuH+RlM0dMCR6jVpQ1m/Z2+i2rTREMyi6CuN2zzA==
+"@readr-media/react-theatre@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-theatre/-/react-theatre-1.3.0.tgz#61f549d6568e6e2447090c36be91a36c9aeea9a8"
+  integrity sha512-W3eqVXKlyyo6ZCsg+Xn8zAGTddzBAnRgD1Ri6kgIA+Xa23kyfyVq/h3DlPhcMKOhfl34P1ia/0oZbwSVmjbhOA==
   dependencies:
     "@theatre/core" "0.6.1"
     react-transition-group "^4.4.5"

--- a/packages/theatre/package.json
+++ b/packages/theatre/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-theatre",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "description": "",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/theatre/src/react-components/elements/font.js
+++ b/packages/theatre/src/react-components/elements/font.js
@@ -47,5 +47,7 @@ export default function FontElement({ id, sheet }) {
     })
   }, [object])
 
-  return <FontWrapper style={style}>{content}</FontWrapper>
+  return (
+    <FontWrapper style={style} dangerouslySetInnerHTML={{ __html: content }} />
+  )
 }


### PR DESCRIPTION
### Notable Changes 
- theatre：文字元件依照使用需求改為 `dangerouslySetInnerHTML`。
- dropping-text：套件預設背景改為 #000000，以覆蓋後方資訊。（補推）
- embed-code-generator：更新相關套件版本。