### PR TITLE
fix(ecg): handle unexpected errors caused by repeated hydration

### DIFF
--- a/packages/embed-code-generator/src/build-code/client.js
+++ b/packages/embed-code-generator/src/build-code/client.js
@@ -14,6 +14,15 @@ function hydrate(namespace, pkgName, Component) {
       const container = document.getElementById(uuid)
       hydrateRoot(container, <Component {...dataOfComponent} />)
     })
+    // Clean up data to avoid repeated hydration.
+    // Repeated hydration might cause unexpected error, such as:
+    // there are two karaoke embedded codes in the same web page.
+    // The first one embed code script has already hydrated these two embedded codes
+    // on the DOM.
+    // However, the second embed code script will hydrate them again since
+    // `window[namespace][pkgName]` has data.
+    // The second hydration will cause unexpected React errors.
+    window[namespace][pkgName] = []
   }
 }
 
@@ -26,6 +35,8 @@ function render(namespace, pkgName, Component) {
       const root = createRoot(container)
       root.render(<Component {...dataOfComponent} />)
     })
+    // Clean up data to avoid repeated rendering.
+    window[namespace][pkgName] = []
   }
 }
 


### PR DESCRIPTION
### Bug 說明
當多個同性質的 embed code （例如：多個 karaoke embed code）放在同一個頁面時，複數個 karaoke script 執行會導致元件無法正常呈現，出現非預期的 React 錯誤。

### 解法
避免重複 react hydration。
將已經 hydration 完的資料清空，因此，複數個 script 執行時，不會產生兩次以上的 hydration。