### PR TITLE
feat(election-widgets): add useClickOutside

### DIFF
--- a/packages/election-widgets/package.json
+++ b/packages/election-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-election-widgets",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.1-alpha.2",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/election-widgets/src/votes-comparison/react-components/hooks/use-click-outside.js
+++ b/packages/election-widgets/src/votes-comparison/react-components/hooks/use-click-outside.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+/**
+ *
+ * @param {React.MutableRefObject<null | HTMLElement>} ref
+ * @param {Function} callback
+ * @returns {void}
+ */
+export default function useClickOutside(ref, callback) {
+  useEffect(() => {
+    /** @type {EventListener}*/
+    const handleClickOutside = (event) => {
+      const targetNode = /** @type {Node} */ (event.target)
+      if (ref.current && !ref.current.contains(targetNode)) {
+        callback()
+      }
+    }
+    document.addEventListener('click', handleClickOutside, true)
+    return () => {
+      document.removeEventListener('click', handleClickOutside, true)
+    }
+  }, [ref, callback])
+}

--- a/packages/election-widgets/src/votes-comparison/react-components/selector.js
+++ b/packages/election-widgets/src/votes-comparison/react-components/selector.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react' // eslint-disable-lin
 import breakpoints from './breakpoint'
 import styled from 'styled-components'
 import { CloseIcon } from './icons'
+import useClickOutside from './hooks/use-click-outside'
 
 const Container = styled.div`
   ${(props) => {
@@ -244,7 +245,10 @@ function Picker({ options, onSelect }) {
   }, [])
 
   const containerRef = useRef(null)
-
+  const bodyRef = useRef(null)
+  useClickOutside(bodyRef, () => {
+    onSelect(undefined)
+  })
   const optionsJsx = options.map((o, idx) => {
     return (
       <StyledOption key={idx} onClick={() => onSelect(o)}>
@@ -255,7 +259,7 @@ function Picker({ options, onSelect }) {
 
   return (
     <LightBoxContainer ref={containerRef}>
-      <LightBoxBody>
+      <LightBoxBody ref={bodyRef}>
         <div>
           <span>請選擇選區</span>
           <div onClick={() => onSelect(undefined)}>


### PR DESCRIPTION
## Notable Change
1.  新增一個custom hook useClickOutside，該hooks用於點擊特定元件以外的範圍時，會執行某個callback function。
2. 使用該hook 於selector，使其點擊選區選單外部時，可以關閉選單，以提升手機使用者體驗。