### PR TITLE
refactor(election-widget/votes): refactor `fullDistrictName` in manager/loader

### DIFF
--- a/packages/election-widgets/package.json
+++ b/packages/election-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-election-widgets",
-  "version": "1.1.1-alpha.2",
+  "version": "1.1.1-alpha.3",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/election-widgets/src/votes-comparison/data-loader.js
+++ b/packages/election-widgets/src/votes-comparison/data-loader.js
@@ -155,23 +155,20 @@ export default class Loader {
       if (includes.indexOf(d?.type) > -1) {
         switch (d?.type) {
           case 'plainIndigenous': {
-            d.districtName = `第${d.districtName}選區（平地）`
-            d.fullDistrictName = d.districtName
+            d.fullDistrictName = `第${d.districtName}選區（平地）`
             districts.push(d)
             break
           }
 
           case 'mountainIndigenous': {
-            d.districtName = `第${d.districtName}選區（山地）`
-            d.fullDistrictName = d.districtName
+            d.fullDistrictName = `第${d.districtName}選區（山地）`
             districts.push(d)
             break
           }
 
           case 'indigenous':
           case 'normal': {
-            d.districtName = `第${d.districtName}選區`
-            d.fullDistrictName = d.districtName
+            d.fullDistrictName = `第${d.districtName}選區`
             districts.push(d)
             break
           }
@@ -208,8 +205,15 @@ export default class Loader {
         year,
         district,
         interval: loadInterval,
+      }).then((resolvedData) => {
+        resolvedData.districts = resolvedData.districts.map((district) => ({
+          ...district,
+          fullDistrictName: `第${district.districtName}選區`, //data for `options` & `row.id` & `row.group`
+        }))
+        return resolvedData
       })
     }
+
     return this.loadData({
       type: 'councilMember',
       year,
@@ -258,13 +262,26 @@ export default class Loader {
         year,
         district,
         interval: loadInterval,
+      }).then((resolvedData) => {
+        resolvedData.districts = resolvedData.districts.map((district) => ({
+          ...district,
+          fullDistrictName: `第${district.districtName}選區`, //data for `options` & `row.id` & `row.group`
+        }))
+        return resolvedData
       })
     }
+
     return this.loadData({
       type: 'legislator',
       subtype,
       year,
       district,
+    }).then((resolvedData) => {
+      resolvedData.districts = resolvedData.districts.map((district) => ({
+        ...district,
+        fullDistrictName: `第${district.districtName}選區`, //data for `options` & `row.id` & `row.group`
+      }))
+      return resolvedData
     })
   }
 

--- a/packages/election-widgets/src/votes-comparison/react-components/index.js
+++ b/packages/election-widgets/src/votes-comparison/react-components/index.js
@@ -364,17 +364,18 @@ export function CouncilMember({
     </StyledTabs>
   ) : null
 
-  /** @type {string[]} */
-  const options = districts.map((d) => d.districtName)
-
-  const [districtName, setDistrictName] = useState(scrollTo || options?.[0])
-
   const dataManager = dataManagerFactory().newDataManager({
     districts,
     type: 'councilMember',
     year,
     title,
   })
+
+  /** @type {string[]} */
+  const options = districts.map(
+    (d) => d.fullDistrictName || dataManager.genFullDistrictName(d.districtName)
+  )
+  const [districtName, setDistrictName] = useState(scrollTo || options?.[0])
 
   useEffect(() => {
     setDistrictName(scrollTo || options?.[0])
@@ -400,7 +401,6 @@ export function CouncilMember({
             onChange('selector', n)
           }
         }}
-        renderFullOption={(option) => `第${option}選舉區`}
       />
       <StyledList dataManager={dataManager} scrollTo={districtName} />
     </Container>
@@ -505,7 +505,7 @@ function _EVC({ className, dataManager, scrollTo, onChange = () => {} }) {
   /** @type {Election} */
   const data = dataManager.getData()
   const options = data?.districts.map(
-    (c) => c.fullDistrictName || c.districtName
+    (c) => c.fullDistrictName || dataManager.genFullDistrictName(c.districtName)
   )
 
   const [districtName, setDistrictName] = useState(scrollTo || options?.[0])

--- a/packages/election-widgets/src/votes-comparison/react-components/manager.js
+++ b/packages/election-widgets/src/votes-comparison/react-components/manager.js
@@ -170,6 +170,14 @@ export class DataManager {
       group: '',
     }
   }
+
+  /**
+   *  @param {string} dn
+   *  @returns {string}
+   */
+  genFullDistrictName(dn) {
+    return dn
+  }
 }
 
 function CandidateImg({ imgSrc }) {
@@ -238,11 +246,10 @@ export class CouncilMemberDataManager extends DataManager {
   }
 
   /**
-   *  @param {string} dn
-   *  @returns {string}
+   *  @override
    */
   genFullDistrictName(dn) {
-    return `第${dn}選舉區`
+    return `第${dn}選區`
   }
 
   /**
@@ -264,15 +271,21 @@ export class CouncilMemberDataManager extends DataManager {
           group: '',
         }
 
-        row.group = d.districtName
-        row.id = `${d.districtName}-${cIdx}`
-        let districtName = ''
+        // `districtName` 為 (1)下拉選單內容 (2)「地區」欄內容 (3)scrollTo 對應的 id 資訊
+        /** @type {string} */
+        let districtName =
+          d.fullDistrictName || this.genFullDistrictName(d.districtName) || ''
+        row.id = `${districtName}-${cIdx}` // data for `data-row-id`
+        row.group = districtName
+
+        //「地區」欄-內容小標（除了 cIdx[0] 外的都不顯示小標）
+        /** @type {string} */
+        let areaLabel = ''
         if (cIdx === 0) {
-          districtName =
-            d.fullDistrictName || this.genFullDistrictName(d.districtName)
+          areaLabel = districtName
         }
         row.cells = this.buildRowFromCandidate(c)
-        row.cells.unshift([{ label: districtName }])
+        row.cells.unshift([{ label: areaLabel }])
         this.rows.push(row)
       })
     })
@@ -284,7 +297,7 @@ export class CouncilMemberDataManager extends DataManager {
    *  @param {string} districtName
    *  @returns {Row}
    */
-  findRowByDistrictName(districtName = '01') {
+  findRowByDistrictName(districtName = '第01選區') {
     return this.rows.find((r) => {
       return r.group === districtName
     })
@@ -352,7 +365,7 @@ export class LegislatorPartyDataManager extends DataManager {
         },
       ],
       // 政黨
-      this.buildPartyCell([p.party]),
+      this.buildPartyCell([p?.party]),
       // 得票數
       [
         {
@@ -362,7 +375,7 @@ export class LegislatorPartyDataManager extends DataManager {
       // 得票率
       [
         {
-          label: p?.tksRate1?.toLocaleString() ?? '-',
+          label: typeof p?.tksRate1 === 'number' ? `${p?.tksRate1}%` : '-',
         },
       ],
       // 當選席次


### PR DESCRIPTION
## Notable Changes 

### 修改說明
- 選舉類型 `councilMember`（縣市議員）/ `legislator`（立委）針對 `第OO選區` 有不同處理邏輯，但各自分散在 data-loader / data-manager / EVC 內管理。
- 此 PR 重構原有 `fullDistrictName` 顯示邏輯，將 「下拉選單」、「地區欄-內容」、「data-row-id」、「scrollTo anchor」都會共用到的 `fullDistrictName` 改為統一在 data-loader 內處理。

### 異動內容
- 修改 Data-loader `loadCouncilMemberData`、`loadLegislatorData`：
   - 取回的 data，一律在 data.districts 內新增 `fullDistrictName`，作為「下拉選單」、「地區欄-內容」、「data-row-id」、「scrollTo」資料來源。
   - 既有的 `districtName` 維持 `01` 資料格式，新增的 `fullDistrictName` 格式為 `第01選區`。
- 修改 Data-loader `loadCouncilMemberDataForElectionMapProject`：

   - 取回的 data，一律在 data.districts 內新增 `fullDistrictName`，作為「下拉選單」、「地區欄-內容」、「data-row-id」、「scrollTo」資料來源。
   - 既有的 `districtName` 維持 `01` 資料格式，依照 `subtype` 新增 `fullDistrictName`，格式分別為：
   
     - plainIndigenous --> `第OO選區（平地）` 
     - mountainIndigenous --> `第OO選區（山地）` 
     - normal --> `第OO選區` 

### 其他
- `@readr-media/react-election-widgets` 版本升至 `1.1.1-alpha.3`。
- 修正 `loadLegislatorData` switch/case 錯誤。