### PR TITLE
fix(election-widget): adjust `version` logic in votes-comparison/seat-chart

### DIFF
--- a/packages/election-widgets/CHANGELOG.md
+++ b/packages/election-widgets/CHANGELOG.md
@@ -1,36 +1,81 @@
 # @readr-media/react-election-widgets Changelog
 
+## 2024-01-08, Version 1.1.1
+
+### Commits
+
+- \[[`5b46e106ca`](https://github.com/readr-media/react-theatre/commit/5b46e106ca)] - fix(election-widget): adjust max-width & remove useEffect (Xuan)
+- \[[`172fb7b093`](https://github.com/readr-media/react-theatre/commit/172fb7b093)] - fix(election-widget): adjust `version` logic in votes-comparison (Xuan)
+- \[[`363a758a18`](https://github.com/readr-media/react-theatre/commit/363a758a18)] - fix(election-widget): remove `version` props in seat-chart (Xuan)
+- \[[`a84efcf376`](https://github.com/readr-media/react-theatre/commit/a84efcf376)] - chore(election-widget): update version to `1.1.1` (Xuan)
+- \[[`a9e41d9031`](https://github.com/readr-media/react-theatre/commit/a9e41d9031)] - refactor(liveblog): update callback object (caesar)
+- \[[`7c630d7768`](https://github.com/readr-media/react-theatre/commit/7c630d7768)] - refactor(liveblog): add more callback for outsider to track ga (caesar)
+- \[[`20473802e3`](https://github.com/readr-media/react-theatre/commit/20473802e3)] - chore(election-widget): bump version to `1.1.1-alpha.9` (Xuan)
+- \[[`5fba844838`](https://github.com/readr-media/react-theatre/commit/5fba844838)] - style(election-widget/vote): adjust container width (Xuan)
+- \[[`52bc3b73ce`](https://github.com/readr-media/react-theatre/commit/52bc3b73ce)] - chore(election-widget): change version to `1.1.1-alpha.8` (Xuan)
+- \[[`c274fa7aa7`](https://github.com/readr-media/react-theatre/commit/c274fa7aa7)] - docs(election-widget/vote): update README (Xuan)
+- \[[`a2599bb5cc`](https://github.com/readr-media/react-theatre/commit/a2599bb5cc)] - fix(election-widget/vote): remove fullDistrictName in specific loaders (Xuan)
+- \[[`f61a1ffec0`](https://github.com/readr-media/react-theatre/commit/f61a1ffec0)] - chore(election-widget): upgrade version to `1.1.1-alpha.7` (Xuan)
+- \[[`bb407854b1`](https://github.com/readr-media/react-theatre/commit/bb407854b1)] - fix(map/vote): `loadLegislatorData` error handle (Xuan)
+- \[[`9d0470bcf9`](https://github.com/readr-media/react-theatre/commit/9d0470bcf9)] - chore(election-widget): upgrade version to `1.1.1-alpha.6` (Xuan)
+- \[[`1db4c0d136`](https://github.com/readr-media/react-theatre/commit/1db4c0d136)] - feature(election-widgets/seat): add switch mode (caesar)
+- \[[`b5a9ba629a`](https://github.com/readr-media/react-theatre/commit/b5a9ba629a)] - chore(election-widgets): upgrade version to `1.1.1-alpha.5` (Xuan)
+- \[[`bc51d58021`](https://github.com/readr-media/react-theatre/commit/bc51d58021)] - fix(election-widget/vote): modify `loadCouncilMemberData` (Xuan)
+- \[[`6787dc7d65`](https://github.com/readr-media/react-theatre/commit/6787dc7d65)] - refactor(election-map): fetch legislator seat data (caesar)
+- \[[`bba0deea02`](https://github.com/readr-media/react-theatre/commit/bba0deea02)] - fix(election-map): lack of break in switch syntax (caesar)
+- \[[`c3911ce362`](https://github.com/readr-media/react-theatre/commit/c3911ce362)] - chore(election-widgets): upgrade version to `1.1.1-alpha.3` (Xuan)
+- \[[`3a377e257f`](https://github.com/readr-media/react-theatre/commit/3a377e257f)] - fix(election-widgets/vote): refactor `fullDistrictName` in councilMember/legislator manager (Xuan)
+- \[[`808e75de28`](https://github.com/readr-media/react-theatre/commit/808e75de28)] - fix(election-widgets/vote): modify `options` data (Xuan)
+- \[[`b4cad41256`](https://github.com/readr-media/react-theatre/commit/b4cad41256)] - fix(election-widget/vote): add `fullDistrictName` in councilMember/legislator loader (Xuan)
+- \[[`3f0966f64e`](https://github.com/readr-media/react-theatre/commit/3f0966f64e)] - chore(election-widgets): bump version into `1.1.1-alpha.2` (DianYangFu)
+- \[[`c8a6a0b04c`](https://github.com/readr-media/react-theatre/commit/c8a6a0b04c)] - feat(election-widgets): use `useClickOutside` to close selector (DianYangFu)
+- \[[`7d2a08c807`](https://github.com/readr-media/react-theatre/commit/7d2a08c807)] - feat(election-widgets): add `useClickOutside` (DianYangFu)
+- \[[`939de0445f`](https://github.com/readr-media/react-theatre/commit/939de0445f)] - fix(election-widget): add head notion & tilt style ( for president ) (Xuan)
+- \[[`f3006aa140`](https://github.com/readr-media/react-theatre/commit/f3006aa140)] - docs(election-widget): adjust LegislatorParty type ( tksRate1 / tksRate2 ) (Xuan)
+- \[[`e01fdff41b`](https://github.com/readr-media/react-theatre/commit/e01fdff41b)] - style(election-widget): adjust ImgBlock size & center error (Xuan)
+- \[[`474c2f501f`](https://github.com/readr-media/react-theatre/commit/474c2f501f)] - style(election-widget): update AnonymousIcon svg (Xuan)
+- \[[`ee53ff9e04`](https://github.com/readr-media/react-theatre/commit/ee53ff9e04)] - fix(votes-comparison): adjust worging & remove console (Xuan)
+- \[[`b3cfbea79d`](https://github.com/readr-media/react-theatre/commit/b3cfbea79d)] - feat(votes-comparison): add data manager for legislator indigenous (Xuan)
+- \[[`44044e0e6a`](https://github.com/readr-media/react-theatre/commit/44044e0e6a)] - fix(votes-comparison): adjust loadLegislatorData ( add props: subtype) (Xuan)
+- \[[`c0b34e6b37`](https://github.com/readr-media/react-theatre/commit/c0b34e6b37)] - feat(votes-comparison): election.type add legislator-district/mountainIndigenous/plainIndigenous (Xuan)
+- \[[`f95006eb20`](https://github.com/readr-media/react-theatre/commit/f95006eb20)] - fix(votes-compare): add typedef `LegislatorIndigenousElection` & adjust `LegislatorElection` type setting (Xuan)
+
 ## 2022-11-23, Version 1.0.5
-* \[[`e0e921a3cd`](https://github.com/readr-media/react-election-widgets/commit/e0e921a3cd)] - chore(ew): update version to 1.0.5 (nickhsine)
-* \[[`fd07f2cbf4`](https://github.com/readr-media/react-election-widgets/commit/fd07f2cbf4)] - fix(seat-chart): get wrong default party color (caesarWHLee)
+
+### Commits
+
+- \[[`e0e921a3cd`](https://github.com/readr-media/react-election-widgets/commit/e0e921a3cd)] - chore(ew): update version to 1.0.5 (nickhsine)
+- \[[`fd07f2cbf4`](https://github.com/readr-media/react-election-widgets/commit/fd07f2cbf4)] - fix(seat-chart): get wrong default party color (caesarWHLee)
 
 ## 2022-11-23, Version 1.0.4
 
 ### Commits
-* \[[`5760a153b1`](https://github.com/readr-media/react-election-widgets/commit/5760a153b1)] - chore(ew): update version to 1.0.4 (nickhsine)
-* \[[`5fe4959267`](https://github.com/readr-media/react-election-widgets/commit/5fe4959267)] - doc(ew): update CHANGELOG.md (nickhsine)
-* \[[`2fa5d71459`](https://github.com/readr-media/react-election-widgets/commit/2fa5d71459)] - fix(ew/seat-chart): wrong api URL (nickhsine)
+
+- \[[`5760a153b1`](https://github.com/readr-media/react-election-widgets/commit/5760a153b1)] - chore(ew): update version to 1.0.4 (nickhsine)
+- \[[`5fe4959267`](https://github.com/readr-media/react-election-widgets/commit/5fe4959267)] - doc(ew): update CHANGELOG.md (nickhsine)
+- \[[`2fa5d71459`](https://github.com/readr-media/react-election-widgets/commit/2fa5d71459)] - fix(ew/seat-chart): wrong api URL (nickhsine)
 
 ## 2022-11-23, Version 1.0.3
 
 ### Commits
-* \[[`6773f2219b`](https://github.com/readr-media/react-election-widgets/commit/6773f2219b)] - chore(ew): update version to 1.0.3 (nickhsine)
-* \[[`f9fc20a63e`](https://github.com/readr-media/react-election-widgets/commit/f9fc20a63e)] - doc(ew): update CHANGELOG.md (nickhsine)
-* \[[`9ceeb24476`](https://github.com/readr-media/react-election-widgets/commit/9ceeb24476)] - style(ew/vc): set lightbox width for mobile device (nickhsine)
 
-## 2022-11-23, Version 1.0.2 
+- \[[`6773f2219b`](https://github.com/readr-media/react-election-widgets/commit/6773f2219b)] - chore(ew): update version to 1.0.3 (nickhsine)
+- \[[`f9fc20a63e`](https://github.com/readr-media/react-election-widgets/commit/f9fc20a63e)] - doc(ew): update CHANGELOG.md (nickhsine)
+- \[[`9ceeb24476`](https://github.com/readr-media/react-election-widgets/commit/9ceeb24476)] - style(ew/vc): set lightbox width for mobile device (nickhsine)
+
+## 2022-11-23, Version 1.0.2
 
 ### Commits
-* \[[`af038a8294`](https://github.com/readr-media/react/commit/af038a8294)] - chore(ew): update version to 1.0.2 (nickhsine)
-* \[[`bc1b972a22`](https://github.com/readr-media/react/commit/bc1b972a22)] - fix(ew/vc): fail to scroll to left on iOS device (nickhsine)
-* \[[`caac474e57`](https://github.com/readr-media/react/commit/caac474e57)] - chore(election-widgets): update version to 1.0.1 (nickhsine)
-* \[[`64b8610d65`](https://github.com/readr-media/react/commit/64b8610d65)] - chore(election-widgets): add missing dependencies (nickhsine)
-* \[[`b1c6aef38a`](https://github.com/readr-media/react/commit/b1c6aef38a)] - chore(election-widgets): update stable version to 1.0.0 (nickhsine)
-* \[[`e8b365529b`](https://github.com/readr-media/react/commit/e8b365529b)] - refactor(election-widgets): update src/index.js. Destruct export object (nickhsine)
-* \[[`789afe6a79`](https://github.com/readr-media/react/commit/789afe6a79)] - fix(election-widgets): react hydration error due to server/client side mismatch (nickhsine)
-* \[[`fa3f5b7c4d`](https://github.com/readr-media/react/commit/fa3f5b7c4d)] - chore(election-widgets): update version to 1.0.0-beta.2 (nickhsine)
-* \[[`176595d3e6`](https://github.com/readr-media/react/commit/176595d3e6)] - refactor(election-widgets)!: rename folders (nickhsine)
-* \[[`a921849865`](https://github.com/readr-media/react/commit/a921849865)] - chore(election-widgets): update version to 1.0.0-beta.1 (nickhsine)
-* \[[`39e940da4c`](https://github.com/readr-media/react/commit/39e940da4c)] - feat(election-widgets): copy election-votes-comparison source codes to election-widgets (nickhsine)
-* \[[`46d5a5a667`](https://github.com/readr-media/react/commit/46d5a5a667)] - **feat**: add packages/election-widgets (nickhsine)
 
+- \[[`af038a8294`](https://github.com/readr-media/react/commit/af038a8294)] - chore(ew): update version to 1.0.2 (nickhsine)
+- \[[`bc1b972a22`](https://github.com/readr-media/react/commit/bc1b972a22)] - fix(ew/vc): fail to scroll to left on iOS device (nickhsine)
+- \[[`caac474e57`](https://github.com/readr-media/react/commit/caac474e57)] - chore(election-widgets): update version to 1.0.1 (nickhsine)
+- \[[`64b8610d65`](https://github.com/readr-media/react/commit/64b8610d65)] - chore(election-widgets): add missing dependencies (nickhsine)
+- \[[`b1c6aef38a`](https://github.com/readr-media/react/commit/b1c6aef38a)] - chore(election-widgets): update stable version to 1.0.0 (nickhsine)
+- \[[`e8b365529b`](https://github.com/readr-media/react/commit/e8b365529b)] - refactor(election-widgets): update src/index.js. Destruct export object (nickhsine)
+- \[[`789afe6a79`](https://github.com/readr-media/react/commit/789afe6a79)] - fix(election-widgets): react hydration error due to server/client side mismatch (nickhsine)
+- \[[`fa3f5b7c4d`](https://github.com/readr-media/react/commit/fa3f5b7c4d)] - chore(election-widgets): update version to 1.0.0-beta.2 (nickhsine)
+- \[[`176595d3e6`](https://github.com/readr-media/react/commit/176595d3e6)] - refactor(election-widgets)!: rename folders (nickhsine)
+- \[[`a921849865`](https://github.com/readr-media/react/commit/a921849865)] - chore(election-widgets): update version to 1.0.0-beta.1 (nickhsine)
+- \[[`39e940da4c`](https://github.com/readr-media/react/commit/39e940da4c)] - feat(election-widgets): copy election-votes-comparison source codes to election-widgets (nickhsine)
+- \[[`46d5a5a667`](https://github.com/readr-media/react/commit/46d5a5a667)] - **feat**: add packages/election-widgets (nickhsine)

--- a/packages/election-widgets/dev/entry.js
+++ b/packages/election-widgets/dev/entry.js
@@ -11,7 +11,6 @@ const votesComparisonRoot = createRoot(
 async function renderSeatChart() {
   const ldr = new widgets.SeatChart.DataLoader({
     apiUrl: 'https://whoareyou-gcs.readr.tw/elections-dev',
-    version: 'v1',
   })
 
   const data = await ldr.loadCouncilMemberData({

--- a/packages/election-widgets/package.json
+++ b/packages/election-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-election-widgets",
-  "version": "1.1.1-alpha.9",
+  "version": "1.1.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/election-widgets/src/seat-chart/data-loader.js
+++ b/packages/election-widgets/src/seat-chart/data-loader.js
@@ -8,20 +8,14 @@ import errors from '@twreporter/errors'
 
 export default class Loader {
   apiUrl = 'https://whoareyou-gcs.readr.tw/elections'
-  version = 'v1'
 
   /**
    *  @constructor
    *  @param {Object} props
    *  @param {string} [props.apiUrl='https://whoareyou-gcs.readr.tw']
-   *  @param {string} [props.version=v2]
    */
-  constructor({
-    apiUrl = 'https://whoareyou-gcs.readr.tw/elections',
-    version = 'v1',
-  }) {
+  constructor({ apiUrl = 'https://whoareyou-gcs.readr.tw/elections' }) {
     this.apiUrl = apiUrl
-    this.version = version === 'v1' ? '' : version
   }
 
   /**
@@ -36,9 +30,7 @@ export default class Loader {
   async loadData({ year, type, filename }) {
     try {
       const axiosRes = await axios.get(
-        this.version
-          ? `${this.apiUrl}/${this.version}/${year}/${type}/${filename}`
-          : `${this.apiUrl}/${year}/${type}/${filename}`
+        `${this.apiUrl}/${year}/${type}/${filename}`
       )
       return axiosRes?.data
     } catch (err) {

--- a/packages/election-widgets/src/votes-comparison/README.md
+++ b/packages/election-widgets/src/votes-comparison/README.md
@@ -11,7 +11,7 @@
 - `mayor`: 縣市長
 - `president`: 總統
 - `referendum`: 公投
-- `legislator`: 立法委員(包含：區域/平地原住民/山地原住民/不分區政黨)
+- `legislator`: 立法委員（包含：區域/平地原住民/山地原住民/不分區政黨）
 
 年份（`year`）的部分，根據不同的選舉類型，有不同的選舉年份。
 目前支援的年份包括：
@@ -31,8 +31,9 @@
 - 2024
 
 然而，因為每種選舉的資料維度不盡相同，
-所以在使用 `DataLoader` 時，需要提供「區域」（`districts`）。
-「縣市議員」和「立法委員（區域）」可以提供的區域包含：
+所以在使用 `DataLoader` 時，需要提供「區域」（`district`）。
+
+1. 「縣市議員」和「立法委員（區域）」可以提供的區域包含：
 
 - `taipeiCity`
 - `newTaipeiCity`
@@ -57,8 +58,14 @@
 - `hsinchuCity`
 - `chiayiCity`
 
-「總統」、「公投」和「縣市首長」的區域為 `all`。
-「立法委員（平地原住民）」、「立法委員（山地原住民）」、「立法委員（不分區）」的區域也為 `all`。
+1. 其餘選舉類型的區域皆為 `all`：
+
+- 縣市長
+- 總統
+- 公投
+- 立法委員（平地原住民）
+- 立法委員（山地原住民）
+- 立法委員（不分區）
 
 範例：
 
@@ -72,7 +79,7 @@ let ldr
 ldr = new DataLoader({
   type: 'councilMember',
   year: '2018',
-  districts: 'taipeiCity',
+  district: 'taipeiCity',
 })
 const data = await ldr.loadData()
 
@@ -80,15 +87,16 @@ const data = await ldr.loadData()
 ldr = new DataLoader({
   type: 'president',
   year: '2020',
-  districts: 'all',
+  district: 'all',
 })
 const data = await ldr.loadData()
 
 // 抓取「2020 年不分區立法委員」選舉結果
 ldr = new DataLoader({
   type: 'legislator',
+  subtype: 'party'
   year: '2020',
-  districts: 'party',
+  district: 'all',
 })
 const data = await ldr.loadData()
 
@@ -96,7 +104,7 @@ const data = await ldr.loadData()
 ldr = new DataLoader({
   type: 'referendum',
   year: '2022',
-  districts: 'all',
+  district: 'all',
 })
 const data = await ldr.loadData()
 ```
@@ -127,7 +135,7 @@ function AnotherComponent(props) {
     let dataLoader = new DataLoader({
       year: '2018', // 年份
       type: 'councilMember', // 選舉類型
-      area: 'taipeiCity', // 縣市
+      district: 'taipeiCity', // 縣市
     })
 
     const handleError = (errMsg, errObj) => {
@@ -186,7 +194,7 @@ async function load() {
   const dataLoader = new DataLoader({
     year: '2018', // 年份
     type: 'councilMember', // 選舉類型
-    area: 'taipeiCity', // 縣市
+    district: 'taipeiCity', // 縣市
   })
 
   let data

--- a/packages/election-widgets/src/votes-comparison/data-loader.js
+++ b/packages/election-widgets/src/votes-comparison/data-loader.js
@@ -85,7 +85,7 @@ export default class Loader {
   }) {
     this.eventEmitter = new events.EventEmitter()
     this.apiUrl = apiUrl
-    this.version = version === 'v1' ? '' : version
+    this.version = version
   }
 
   /**

--- a/packages/election-widgets/src/votes-comparison/data-loader.js
+++ b/packages/election-widgets/src/votes-comparison/data-loader.js
@@ -461,6 +461,7 @@ Loader.electionYears = [
   '2018',
   '2020',
   '2022',
+  '2024',
 ]
 Loader.electionDistricts = [
   'taipeiCity',

--- a/packages/election-widgets/src/votes-comparison/react-components/list.js
+++ b/packages/election-widgets/src/votes-comparison/react-components/list.js
@@ -32,7 +32,7 @@ const Table = styled.div`
       default: {
         return `
           @media ${breakpoint.devices.laptop} {
-            width: 1160px;
+            width: 1200px;
           }
 
           @media ${breakpoint.devices.laptopBelow} {
@@ -411,49 +411,6 @@ export default function List({ className, dataManager, scrollTo }) {
       node.scrollLeft = offsetLeft
     }, 0)
   }, [scrollTo])
-
-  // useEffect(() => {
-  //   // This effect hook is to set list row the same height.
-  //   // For laptop version, the list is a `table`,
-  //   // therefore, browser will automatically calculate the height and width for each row and column.
-  //   // But, in mobile/tablet version, the list is built from `flex`, rather than `table`;
-  //   // we need to adjust the list cell height and width if we want present multiple lines.
-  //   // And the following codes does that.
-  //   //
-  //   // By the way, the reasons we don't render `table` for table/mobile version are:
-  //   // 1. mobile/tablet mockups have vertical headers, but laptop has horizontal headers
-  //   // 2. the mockups modified multiple times. At first, the cell does not support multiple lines.
-  //   //    Therefore, `flex` is a easy way for implementation.
-  //   // 3. if we want to change `flex` to `table`, we have to have two different code blocks to render
-  //   //    mobile/tablet and laptop version.
-
-  //   const node = tableRef.current
-
-  //   // query table cell with multiple lines
-  //   const multiLineCells = node?.querySelectorAll(`[data-multi-lines="true"]`)
-
-  //   //mapping table: key is column id and value is maxHeight.
-  //   //It is used to record which table cell having max height.
-  //   let maxHeightMap = {}
-
-  //   // calculate max height of table cells with the certain `data-column-id` attribute
-  //   multiLineCells?.forEach((cell) => {
-  //     const colId = cell?.getAttribute('data-column-id')
-  //     if (!maxHeightMap.hasOwnProperty(colId)) {
-  //       maxHeightMap[colId] = cell.offsetHeight
-  //     } else if (maxHeightMap[colId] < cell?.offsetHeight) {
-  //       maxHeightMap[colId] = cell.offsetHeight
-  //     }
-  //   })
-
-  //   // set the cells, with the same `data-column-id`, the same height
-  //   for (const colId in maxHeightMap) {
-  //     const cells = node?.querySelectorAll(`[data-column-id="${colId}"]`)
-  //     cells?.forEach((cell) => {
-  //       cell.style.height = `${maxHeightMap[colId]}px`
-  //     })
-  //   }
-  // }, [dataManager])
 
   let previousBgColor = 'dark'
   const rowsJsx = rows.map((row, rowIdx) => {


### PR DESCRIPTION
### Notable Changes
- 發布正式版本至 `1.1.1`。
- 更新 `README`、`CHANGELOG`。 
- 移除 `seat-chart` 中的 `version` 參數（因「席次表」資料分類上不會有 version，只會有 year、type 的區分）。
- 修改 `vote-comparison` 中 `version` 針對 `v1` 的特殊處理邏輯：

   - 「票數比較」的資料拿取路徑，統一改為 `whoareyou-gcs.readr.tw/elections/[version]`。