### PR TITLE
chore(ecg): bump version to `2.4.3-alpha.18`

### DIFF
--- a/packages/embed-code-generator/package.json
+++ b/packages/embed-code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-embed-code-generator",
-  "version": "2.4.3-alpha.17",
+  "version": "2.4.3-alpha.18",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "@readr-media/react-qa-list": "2.0.1",
     "@readr-media/react-questionnaire": "2.0.0",
     "@readr-media/react-random-text-selector": "^1.0.2",
-    "@readr-media/react-theatre": "^1.3.0",
+    "@readr-media/react-theatre": "^1.4.0-alpha.1",
     "@readr-media/react-three-story-points": "1.0.2",
     "@readr-media/react-timeline": "1.1.0-alpha.1",
     "lodash": "^4.17.21",

--- a/packages/embed-code-generator/yarn.lock
+++ b/packages/embed-code-generator/yarn.lock
@@ -1316,6 +1316,16 @@
     url "^0.11.1"
     uuid "^9.0.0"
 
+"@readr-media/react-theatre@^1.4.0-alpha.1":
+  version "1.4.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-theatre/-/react-theatre-1.4.0-alpha.1.tgz#03c8481886799bb63920fc442959e31d2cd9899a"
+  integrity sha512-ZdfsWlk9Tdu4PXWWkeSICEV0fqXR4YQ0gbUypKvBwn6Qk1/hbQWn6hjA56QJM2YVDu22RlXRT+Dxa6oztkkv8A==
+  dependencies:
+    "@theatre/core" "0.6.1"
+    react-transition-group "^4.4.5"
+    url "^0.11.1"
+    uuid "^9.0.0"
+
 "@readr-media/react-three-story-points@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@readr-media/react-three-story-points/-/react-three-story-points-1.0.2.tgz#7a24cdc13cea2fda1ac83df1f610bdd943f0fef6"


### PR DESCRIPTION
### Notable Changes 
- 更新 dependencies `@readr-media/react-theatre` 版本為`1.4.0-alpha.1`。
- 版號升至 `2.4.3-alpha.18`。