### PR TITLE
chore(infinite-scroll): bump package version to 1.2.0

### DIFF
--- a/packages/infinite-scroll-list/CHANGELOG.md
+++ b/packages/infinite-scroll-list/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @readr-media/react-infinite-scroll-list Changelog
 
+## 2024-06-25, Version 1.1.2
+
+### Notable Changes
+* Move `ts-xor` from devDependencies to dependencies
+
+### Commits
+* \[[`a8de9bd332`](https://github.com/readr-media/react/commit/a8de9bd332)] - chore(infinite-scroll): bump package version (Tsuki Akiba)
+* \[[`7f59530228`](https://github.com/readr-media/react/commit/7f59530228)] - chore(infinite-scroll): move ts-xor from devDependencies to dependencies (Tsuki Akiba)
+* \[[`fa2b833431`](https://github.com/readr-media/react/commit/fa2b833431)] - docs(infinite-scroll): update CHANGELOG (Tsuki Akiba)
+
 ## 2024-06-25, Version 1.1.1
 
 ### Notable Changes

--- a/packages/infinite-scroll-list/CHANGELOG.md
+++ b/packages/infinite-scroll-list/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @readr-media/react-infinite-scroll-list Changelog
 
+## 2024-07-11, Version 1.2.0
+
+### Notable Changes
+* Update `initialList` related handle.  If length of `initialList` is less than `pageSize`, load-more trigger won't display.
+
+### Commits
+* \[[`9b51b3dec0`](https://github.com/readr-media/react-infinite-scroll-list/commit/9b51b3dec0)] - chore(infinite-scroll): update package version (Tsuki Akiba)
+* \[[`f145a5a941`](https://github.com/readr-media/react-infinite-scroll-list/commit/f145a5a941)] - refactor(infinite-scroll): update initialList related handle (Tsuki Akiba)
+* \[[`7147b78f88`](https://github.com/readr-media/react-infinite-scroll-list/commit/7147b78f88)] - docs(infinite-scroll): update CHANGELOG (Tsuki Akiba)
+
 ## 2024-06-25, Version 1.1.2
 
 ### Notable Changes

--- a/packages/infinite-scroll-list/CHANGELOG.md
+++ b/packages/infinite-scroll-list/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @readr-media/react-infinite-scroll-list Changelog
 
+## 2024-06-25, Version 1.1.1
+
+### Notable Changes
+* Fix error that occurs after manually triggering load-more effect
+
+### Commits
+* \[[`72f2df3efd`](https://github.com/readr-media/react/commit/72f2df3efd)] - chore(infinite-scroll): bump package version (Tsuki Akiba)
+* \[[`66b0b4f04c`](https://github.com/readr-media/react/commit/66b0b4f04c)] - fix(infinite-scroll): error occurs after manually triggering load-more (Tsuki Akiba)
+* \[[`175b263c46`](https://github.com/readr-media/react/commit/175b263c46)] - docs(infinite-scroll): update changelog 
+
 ## 2024-06-24, Version 1.1.0
 
 ### Notable Changes

--- a/packages/infinite-scroll-list/package.json
+++ b/packages/infinite-scroll-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-infinite-scroll-list",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "",
   "main": "lib/index.js",
   "types": "dist/index.d.ts",

--- a/packages/infinite-scroll-list/package.json
+++ b/packages/infinite-scroll-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-infinite-scroll-list",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "main": "lib/index.js",
   "types": "dist/index.d.ts",

--- a/packages/infinite-scroll-list/package.json
+++ b/packages/infinite-scroll-list/package.json
@@ -33,8 +33,7 @@
     "dist",
     "CHANGELOG.md"
   ],
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "ts-xor": "^1.3.0"
   }
 }

--- a/packages/infinite-scroll-list/package.json
+++ b/packages/infinite-scroll-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-infinite-scroll-list",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "lib/index.js",
   "types": "dist/index.d.ts",

--- a/packages/infinite-scroll-list/src/infinite-scroll-list.tsx
+++ b/packages/infinite-scroll-list/src/infinite-scroll-list.tsx
@@ -50,11 +50,6 @@ export default function InfiniteScrollList<T>({
   const [renderSize, setRenderSize] = useState(pageSize)
   const [dataList, setDataList] = useState([...initialList])
 
-  // In strict mode, we need to monitor changes from upstream
-  useEffect(() => {
-    setDataList(initialList)
-  }, [initialList])
-
   const checkIsMoreData = useCallback(() => {
     if (typeof amountOfElements === 'number' && amountOfElements) {
       return dataList.length < amountOfElements
@@ -109,6 +104,8 @@ export default function InfiniteScrollList<T>({
       return
     }
 
+    const oldRenderSize = renderSize
+
     if (isNotEnoughToRender && hasNotFetchedData) {
       const newPage = fetchedPage.current + 1
       isLoading.current = true
@@ -124,21 +121,28 @@ export default function InfiniteScrollList<T>({
           setDataList(list)
         }
 
+        if (amountOfElements) {
+          setRenderSize(Math.min(oldRenderSize + pageSize, amountOfElements))
+        } else {
+          setRenderSize(Math.min(oldRenderSize + pageSize, list.length))
+        }
+
         fetchedPage.current = newPage
         isLoading.current = false
       })
-    }
-
-    if (amountOfElements) {
-      setRenderSize((pre) => Math.min(pre + pageSize, amountOfElements))
     } else {
-      setRenderSize((pre) => Math.min(pre + pageSize, dataList.length))
+      if (amountOfElements) {
+        setRenderSize(Math.min(oldRenderSize + pageSize, amountOfElements))
+      } else {
+        setRenderSize(Math.min(oldRenderSize + pageSize, dataList.length))
+      }
     }
   }, [
     fetchListInPage,
     dataList,
     amountOfElements,
     pageSize,
+    renderSize,
     isNotEnoughToRender,
     hasNotFetchedData,
   ])


### PR DESCRIPTION
## Notable Changes
### 1.1.1
* 修正手動觸發 load-more 效果上的問題
### 1.1.2
* 將 `ts-xor` 加入到 dependencies
### 1.2.0
* 調整與 `initialList` 相關的處理，當 `initialList` 的數量小於 `pageSize` 的情況下，不顯示 load-more 效果