### PR TITLE
fix: prevent SSR crash in image component when source is invalid

### DIFF
--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/react-image",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/image/src/react-components/index.js
+++ b/packages/image/src/react-components/index.js
@@ -203,10 +203,18 @@ export default function CustomImage({
     return defaultImage || ''
   }
 
-  const imagesList = useMemo(
-    () => getImagesList(images, imagesWebP),
-    [images, imagesWebP]
-  )
+  const imagesList = useMemo(() => {
+    try {
+      return getImagesList(images, imagesWebP)
+    } catch (err) {
+      // Prevent SSR crash when images prop is null/invalid
+      // Return empty array to trigger fallback to defaultImage
+      if (debugMode) {
+        console.error('[react-image] Failed to get images list:', err)
+      }
+      return []
+    }
+  }, [images, imagesWebP, debugMode])
   const imageRef = useRef(null)
 
   const [imageSrc, setImageSrc] = useState(getInitialSrc())


### PR DESCRIPTION
- Wrap image list generation in a try-catch block to handle missing or invalid image properties during SSR.
- Fallback to an empty array upon error to trigger the default image display logic.
- Log detailed error information when debug mode is enabled.